### PR TITLE
Introduce arm64 docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  dist:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Determine Go version from go.mod
+        run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - uses: goreleaser/goreleaser-action@v2
+        with:
+          args: release --snapshot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "*"
+      - "v*"
 
 jobs:
   goreleaser:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,26 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: Login to Docker hub
-        run: docker login -u "${{ secrets.DOCKER_HUB_USER }}" -p "${{ secrets.DOCKER_HUB_TOKEN }}" docker.io
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
       - name: Login to Quay.io
-        run: docker login -u "${{ secrets.QUAY_IO_USER }}" -p "${{ secrets.QUAY_IO_TOKEN }}" quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USER }}
+          password: ${{ secrets.QUAY_IO_TOKEN }}
+
       - name: Build changelog from PRs with labels
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,17 +1,24 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
 
+# Blog to build multiarch images with GH, docker buildx and manifests
+# https://carlosbecker.com/posts/multi-platform-docker-images-goreleaser-gh-actions/
+
+# Setup Multiarch builds with docker and QEMU, restart docker service!
+# https://github.com/docker/buildx#building-multi-platform-images
+
 builds:
-- env:
-  - CGO_ENABLED=0 # this is needed to build the single binary
-  goarch:
-  - amd64
-  goos:
-  - linux
+  - env:
+      - CGO_ENABLED=0 # this is needed to build the single binary
+    goarch:
+      - amd64
+      - arm64
+    goos:
+      - linux
 
 archives:
-- format: binary
-  name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+  - format: binary
+    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
 
 checksum:
   name_template: 'checksums.txt'
@@ -20,22 +27,67 @@ snapshot:
   name_template: "{{ .Tag }}-snapshot"
 
 dockers:
-- image_templates:
-  - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}"
-  - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}"
+  - image_templates:
+      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
+      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
 
+    extra_files:
+      - docker/zfs.sh
+      - docker/update-permissions.sh
+    goarch: amd64
+    dockerfile: docker/Dockerfile
+    use_buildx: true
+    build_flag_templates:
+      - "--platform=linux/amd64"
+
+  - image_templates:
+      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
+      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
+
+    extra_files:
+      - docker/zfs.sh
+      - docker/update-permissions.sh
+    goarch: arm64
+    dockerfile: docker/Dockerfile
+    use_buildx: true
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+
+docker_manifests:
   # For prereleases, updating `latest` and the floating tags of the major version does not make sense.
   # Only the image for the exact version should be pushed.
-  - "{{ if not .Prerelease }}docker.io/ccremer/zfs-provisioner:v{{ .Major }}{{ end }}"
-  - "{{ if not .Prerelease }}quay.io/ccremer/zfs-provisioner:v{{ .Major }}{{ end }}"
 
-  - "{{ if not .Prerelease }}docker.io/ccremer/zfs-provisioner:latest{{ end }}"
-  - "{{ if not .Prerelease }}quay.io/ccremer/zfs-provisioner:latest{{ end }}"
+  # Quay.io
+  - name_template: "{{ if not .Prerelease }}quay.io/ccremer/zfs-provisioner:latest{{ end }}"
+    image_templates:
+      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
+      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
 
-  extra_files:
-  - docker/zfs.sh
-  - docker/update-permissions.sh
-  dockerfile: docker/Dockerfile
+  - name_template: "{{ if not .Prerelease }}quay.io/ccremer/zfs-provisioner:v{{ .Major }}{{ end }}"
+    image_templates:
+      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
+      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
+
+  - name_template: "quay.io/ccremer/zfs-provisioner:v{{ .Version }}"
+    image_templates:
+      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
+      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
+
+  # Docker.io
+  - name_template: "{{ if not .Prerelease }}docker.io/ccremer/zfs-provisioner:latest{{ end }}"
+    image_templates:
+      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
+      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
+
+  - name_template: "{{ if not .Prerelease }}docker.io/ccremer/zfs-provisioner:v{{ .Major }}{{ end }}"
+    image_templates:
+      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
+      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
+
+  - name_template: "docker.io/ccremer/zfs-provisioner:v{{ .Version }}"
+    image_templates:
+      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
+      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
 
 release:
   prerelease: auto


### PR DESCRIPTION
Following now on, the `docker.io` and `quay.io` image registries will have new tags with the architecture suffix, either `amd64` or `arm64`.
The GitHub pipeline pushes a docker manifest for the existing `latest`, `<major>` and the `v*` tags, but your container runtime should pull the one image corresponding for your architecture. If your runtime doesn't support manifest images, then you should switch to the new `amd64`-suffixed tags when updating.

Currently supported:
* `amd64` (as it was until now, nothing new here)
* `arm64` (new)