### PR TITLE
Update module sigs.k8s.io/sig-storage-lib-external-provisioner to v8.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,5 @@ require (
 	k8s.io/apimachinery v0.19.1
 	k8s.io/client-go v0.19.1
 	k8s.io/klog/v2 v2.30.0
-	sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0
+	sigs.k8s.io/sig-storage-lib-external-provisioner/v8 v8.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -481,8 +481,8 @@ k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6/go.mod h1:UuqjUnNftUyPE5H
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73 h1:uJmqzgNWG7XyClnU/mLPBWwfKKF1K8Hf8whTseBgJcg=
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
-sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0 h1:IKsKAnscMyIOqyl8s8V7guTcx0QBEa6OT57EPgAgpmM=
-sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0/go.mod h1:DhZ52sQMJHW21+JXyA2LRUPRIxKnrNrwh+QFV+2tVA4=
+sigs.k8s.io/sig-storage-lib-external-provisioner/v8 v8.0.0 h1:vQUoaDxbberC3UwvE+zauyOMkpWlleaVgc75LoDOyy4=
+sigs.k8s.io/sig-storage-lib-external-provisioner/v8 v8.0.0/go.mod h1:ejoxC3K6lnUtjUanKStWadRVnwIuyRPNJGQ4dkExDao=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1 h1:YXTMot5Qz/X1iBRJhAt+vI+HVttY0WkSqqhKxQ0xVbA=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -15,7 +14,7 @@ import (
 	"github.com/knadh/koanf"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/sig-storage-lib-external-provisioner/v6/controller"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v8/controller"
 )
 
 const (
@@ -41,18 +40,14 @@ func main() {
 		klog.Fatalf("Couldn't get in-cluster or kubectl config: %v", err)
 	}
 
-	// Retrieve config und server version
+	// Retrieve config
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		klog.Fatalf("Failed to create kubernetes client: %v", err)
 	}
-	serverVersion, err := clientset.DiscoveryClient.ServerVersion()
-	if err != nil {
-		klog.Fatalf("Failed retrieving server version: %v", err)
-	}
 
 	instance := koanfInstance.String(provisionerInstanceKey)
-	klog.InfoS("Connected to cluster", "host", config.Host, "version", fmt.Sprintf("%s.%s", serverVersion.Major, serverVersion.Minor))
+	klog.InfoS("Connected to cluster", "host", config.Host)
 	p, err := provisioner.NewZFSProvisioner(instance)
 	if err != nil {
 		klog.Fatalf("Failed to create ZFS provisioner: %v", err)
@@ -66,7 +61,6 @@ func main() {
 		clientset,
 		instance,
 		p,
-		serverVersion.GitVersion,
 		controller.MetricsAddress(koanfInstance.String(metricsAddrKey)),
 		controller.MetricsPort(int32(koanfInstance.Int(metricsPortKey))),
 	)

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -11,7 +11,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/sig-storage-lib-external-provisioner/v6/controller"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v8/controller"
 )
 
 // Provision creates a PersistentVolume, sets quota and shares it via NFS.

--- a/pkg/provisioner/provision_test.go
+++ b/pkg/provisioner/provision_test.go
@@ -13,7 +13,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/sig-storage-lib-external-provisioner/v6/controller"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v8/controller"
 )
 
 func TestProvisionNfs(t *testing.T) {

--- a/test/provision_integration_test.go
+++ b/test/provision_integration_test.go
@@ -18,7 +18,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"sigs.k8s.io/sig-storage-lib-external-provisioner/v6/controller"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v8/controller"
 
 	"github.com/ccremer/kubernetes-zfs-provisioner/pkg/provisioner"
 	"github.com/ccremer/kubernetes-zfs-provisioner/pkg/zfs"


### PR DESCRIPTION
updates from v6.3 to v8

No breaking changes for the user are expected.