### PR TITLE
Switch image registry from docker.io to ghcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to Docker Hub
+      - name: Login to ghcr.io
         uses: docker/login-action@v1
         with:
-          registry: docker.io
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Quay.io
+      - name: Login to quay.io
         uses: docker/login-action@v1
         with:
           registry: quay.io

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ snapshot:
 
 dockers:
   - image_templates:
-      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
+      - "ghcr.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
       - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
 
     extra_files:
@@ -41,7 +41,7 @@ dockers:
       - "--platform=linux/amd64"
 
   - image_templates:
-      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
+      - "ghcr.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
       - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
 
     extra_files:
@@ -74,20 +74,20 @@ docker_manifests:
       - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
 
   # Docker.io
-  - name_template: "{{ if not .Prerelease }}docker.io/ccremer/zfs-provisioner:latest{{ end }}"
+  - name_template: "{{ if not .Prerelease }}ghcr.io/ccremer/zfs-provisioner:latest{{ end }}"
     image_templates:
-      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
-      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
+      - "ghcr.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
+      - "ghcr.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
 
-  - name_template: "{{ if not .Prerelease }}docker.io/ccremer/zfs-provisioner:v{{ .Major }}{{ end }}"
+  - name_template: "{{ if not .Prerelease }}ghcr.io/ccremer/zfs-provisioner:v{{ .Major }}{{ end }}"
     image_templates:
-      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
-      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
+      - "ghcr.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
+      - "ghcr.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
 
-  - name_template: "docker.io/ccremer/zfs-provisioner:v{{ .Version }}"
+  - name_template: "ghcr.io/ccremer/zfs-provisioner:v{{ .Version }}"
     image_templates:
-      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
-      - "docker.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
+      - "ghcr.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
+      - "ghcr.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
 
 release:
   prerelease: auto


### PR DESCRIPTION
I've decided to no longer maintain the container image at hub.docker.com.
Instead, the new default registry shall become GitHub's `ghcr.io`.
However, the image tags at docker hub will not be migrated to ghcr.io. To pull older version tags, please pull from quay.io.

The repository at quay.io is currently unaffected.
For the time being, the images at Docker Hub will stay, but there will be no new pushes.