### PR TITLE
Stop image push for quay.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,13 +39,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to quay.io
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_IO_USER }}
-          password: ${{ secrets.QUAY_IO_TOKEN }}
-
       - name: Build changelog from PRs with labels
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v3

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,6 @@ snapshot:
 dockers:
   - image_templates:
       - "ghcr.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
-      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
 
     extra_files:
       - docker/zfs.sh
@@ -42,7 +41,6 @@ dockers:
 
   - image_templates:
       - "ghcr.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
-      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
 
     extra_files:
       - docker/zfs.sh
@@ -57,23 +55,6 @@ docker_manifests:
   # For prereleases, updating `latest` and the floating tags of the major version does not make sense.
   # Only the image for the exact version should be pushed.
 
-  # Quay.io
-  - name_template: "{{ if not .Prerelease }}quay.io/ccremer/zfs-provisioner:latest{{ end }}"
-    image_templates:
-      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
-      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
-
-  - name_template: "{{ if not .Prerelease }}quay.io/ccremer/zfs-provisioner:v{{ .Major }}{{ end }}"
-    image_templates:
-      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
-      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
-
-  - name_template: "quay.io/ccremer/zfs-provisioner:v{{ .Version }}"
-    image_templates:
-      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"
-      - "quay.io/ccremer/zfs-provisioner:v{{ .Version }}-arm64"
-
-  # Docker.io
   - name_template: "{{ if not .Prerelease }}ghcr.io/ccremer/zfs-provisioner:latest{{ end }}"
     image_templates:
       - "ghcr.io/ccremer/zfs-provisioner:v{{ .Version }}-amd64"

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -10,6 +10,6 @@ zfs_dataset := $(zpool_name)/zfs-provisioner
 
 binary ?= kubernetes-zfs-provisioner
 
-IMAGE_REGISTRY ?= quay.io
+IMAGE_REGISTRY ?= ghcr.io
 IMAGE_REPOSITORY ?= $(IMAGE_REGISTRY)/ccremer/zfs-provisioner
 IMAGE_TAG ?= latest


### PR DESCRIPTION
## Summary

* Having everything at GitHub should be fine enough, no need to maintain 2 registries.
* Existing tags and images on quay.io will remain for the time being.
* New images and releases will be pushed to `ghcr.io` only.

Marked as "breaking" since users would potentially need to switch the registry in their configuration. Nothing has changed in behaviour (code).

## Checklist

<!--
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.
-->

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [x] PR contains the label `area:provisioner`
- [x] I have not made _any_ changes in the `charts/` directory.
