### PR TITLE
Allow RBAC permissions for leader election

### DIFF
--- a/charts/kubernetes-zfs-provisioner/Chart.yaml
+++ b/charts/kubernetes-zfs-provisioner/Chart.yaml
@@ -14,7 +14,7 @@ description: Dynamic ZFS persistent volume provisioner for Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.0
+version: 2.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/kubernetes-zfs-provisioner/README.md
+++ b/charts/kubernetes-zfs-provisioner/README.md
@@ -1,6 +1,6 @@
 # kubernetes-zfs-provisioner
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square)
 
 Dynamic ZFS persistent volume provisioner for Kubernetes
 

--- a/charts/kubernetes-zfs-provisioner/templates/rbac.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/rbac.yaml
@@ -1,30 +1,99 @@
 {{- if .Values.rbac.create -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: ClusterRole
 metadata:
-  name: {{ include "kubernetes-zfs-provisioner.fullname" . }}-binding
+  name: '{{ include "kubernetes-zfs-provisioner.fullname" . }}-controller'
   labels:
     {{- include "kubernetes-zfs-provisioner.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:persistent-volume-provisioner
-subjects:
-- kind: ServiceAccount
-  name: {{ include "kubernetes-zfs-provisioner.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+rules:
+# leader election
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - update
+
+# system:controller:endpoint-controller
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - endpoints/restricted
+    verbs:
+      - create
+  - apiGroups:
+      - ''
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+      - watch
+
+# system:persistent-volume-provisioner (deduplicated)
+  - apiGroups:
+      - ''
+    resources:
+      - persistentvolumes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kubernetes-zfs-provisioner.fullname" . }}-leaderelection
+  name: {{ include "kubernetes-zfs-provisioner.fullname" . }}
   labels:
     {{- include "kubernetes-zfs-provisioner.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:controller:endpoint-controller
+  name: '{{ include "kubernetes-zfs-provisioner.fullname" . }}-controller'
 subjects:
 - kind: ServiceAccount
   name: {{ include "kubernetes-zfs-provisioner.serviceAccountName" . }}


### PR DESCRIPTION
## Summary

* Following the release of v1.2.0 (#70 ), we also need to give RBAC permissions for leader election.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:kubernetes-zfs-provisioner`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.

<!--
Remove the section and checklist items that do not apply.
For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
