### PR TITLE
Optional space reservation (thin provisioning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,12 @@ further significant to the provisioner.
 
 ### Storage space
 
-The provisioner uses the `refreservation` and `refquota` ZFS attributes to limit
-storage space for volumes. Each volume can not use more storage space than
-the given resource request and also reserves exactly that much. This means
-that over provisioning is not possible. Snapshots **do not** account for the
-storage space limit, however this provisioner does not do any snapshots or backups.
+By default, the provisioner uses the `refreservation` and `refquota` ZFS attributes
+to limit storage space for volumes. Each volume can not use more storage space than
+the given resource request and also reserves exactly that much. To disable this and
+enable thin provisioning, set `reserveSpace` to `false` in your storage class parameters.
+Snapshots **do not** account for the storage space limit, however this provisioner
+does not do any snapshots or backups.
 
 See [zfs(8)][man zfs] for more information.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ parameters:
   hostname: storage-1.domain.tld
   type: hostpath
   node: storage-1 # the kubernetes.io/hostname label if different than hostname parameter (optional)
+  reserveSpace: true
 ```
 
 Following example configures a storage class for ZFS over [NFS][nfs]:
@@ -80,6 +81,7 @@ parameters:
   hostname: storage-1.domain.tld
   type: nfs
   shareProperties: rw,no_root_squash # no_root_squash by default sets mode to 'ro'
+  reserveSpace: true
 ```
 For NFS, you can also specify other options, as described in [exports(5)][man exports].
 

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/knadh/koanf v1.4.3
-	github.com/mistifyio/go-zfs v2.1.1+incompatible
 	github.com/stretchr/testify v1.8.0
+	github.com/mistifyio/go-zfs/v3 v3.0.1
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
 	k8s.io/client-go v0.24.3
@@ -30,7 +30,7 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/google/uuid v1.1.2 // indirect
+	github.com/google/uuid v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,8 @@ github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLe
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
@@ -317,6 +319,8 @@ github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/mistifyio/go-zfs v2.1.1+incompatible h1:gAMO1HM9xBRONLHHYnu5iFsOJUiJdNZo6oqSENd4eW8=
 github.com/mistifyio/go-zfs v2.1.1+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
+github.com/mistifyio/go-zfs/v3 v3.0.1 h1:YaoXgBePoMA12+S1u/ddkv+QqxcfiZK4prI6HPnkFiU=
+github.com/mistifyio/go-zfs/v3 v3.0.1/go.mod h1:CzVgeB0RvF2EGzQnytKVvVSDwmKJXxkOTUGbNrTja/k=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=

--- a/pkg/provisioner/delete_test.go
+++ b/pkg/provisioner/delete_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	gozfs "github.com/mistifyio/go-zfs"
+	gozfs "github.com/mistifyio/go-zfs/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -41,9 +41,12 @@ func (p *ZFSProvisioner) Provision(ctx context.Context, options controller.Provi
 	storageRequest := options.PVC.Spec.Resources.Requests[v1.ResourceStorage]
 	storageRequestBytes := strconv.FormatInt(storageRequest.Value(), 10)
 	properties[RefQuotaProperty] = storageRequestBytes
-	properties[RefReservationProperty] = storageRequestBytes
 	properties[ManagedByProperty] = p.InstanceName
 	properties[ReclaimPolicyProperty] = string(reclaimPolicy)
+
+	if parameters.ReserveSpace {
+		properties[RefReservationProperty] = storageRequestBytes
+	}
 
 	dataset, err := p.zfs.CreateDataset(datasetPath, parameters.Hostname, properties)
 	if err != nil {

--- a/pkg/zfs/zfs.go
+++ b/pkg/zfs/zfs.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"sync"
 
-	gozfs "github.com/mistifyio/go-zfs"
+	gozfs "github.com/mistifyio/go-zfs/v3"
 	"k8s.io/klog/v2"
 )
 

--- a/test/provision_integration_test.go
+++ b/test/provision_integration_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package test
 
 import (

--- a/test/provision_integration_test.go
+++ b/test/provision_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"context"
 	"flag"
+	"github.com/ccremer/kubernetes-zfs-provisioner/pkg/zfs"
 	gozfs "github.com/mistifyio/go-zfs/v3"
 	"math/rand"
 	"os"
@@ -119,8 +120,6 @@ func provisionDataset(suite *ProvisionTestSuit, name string, parameters map[stri
 }
 
 func assertZfsReservation(t *testing.T, datasetName string, reserve bool) {
-	fmt.Fprintln(os.Stderr, datasetName)
-
 	dataset, err := gozfs.GetDataset(datasetName)
 	assert.NoError(t, err)
 

--- a/test/provision_integration_test.go
+++ b/test/provision_integration_test.go
@@ -6,8 +6,6 @@ import (
 	"bufio"
 	"context"
 	"flag"
-	"fmt"
-	"github.com/ccremer/kubernetes-zfs-provisioner/pkg/zfs"
 	gozfs "github.com/mistifyio/go-zfs/v3"
 	"math/rand"
 	"os"

--- a/test/provision_integration_test.go
+++ b/test/provision_integration_test.go
@@ -1,4 +1,3 @@
-//go:build integration
 // +build integration
 
 package test

--- a/test/provision_integration_test.go
+++ b/test/provision_integration_test.go
@@ -54,7 +54,6 @@ func (suite *ProvisionTestSuit) SetupSuite() {
 }
 
 func (suite *ProvisionTestSuit) TearDownSuite() {
-	//*
 	for _, dataset := range suite.createdDatasets {
 		err := zfs.NewInterface().DestroyDataset(&zfs.Dataset{
 			Name:     *parentDataset + "/" + dataset,
@@ -62,7 +61,6 @@ func (suite *ProvisionTestSuit) TearDownSuite() {
 		}, zfs.DestroyRecursively)
 		require.NoError(suite.T(), err)
 	}
-	//*/
 }
 
 func (suite *ProvisionTestSuit) TestDefaultProvisionDataset() {
@@ -126,18 +124,16 @@ func assertZfsReservation(t *testing.T, datasetName string, reserve bool) {
 	dataset, err := gozfs.GetDataset(datasetName)
 	assert.NoError(t, err)
 
-	refreserved, err2 := dataset.GetProperty("refreservation")
-	fmt.Fprintln(os.Stderr, "HOI! 1 ", refreserved, err2)
-	assert.NoError(t, err2)
+	refreserved, err := dataset.GetProperty("refreservation")
+	assert.NoError(t, err)
 
-	refquota, err3 := dataset.GetProperty("refquota")
-	fmt.Fprintln(os.Stderr, "HOI! 2 ", refquota, err3)
-	assert.NoError(t, err3)
+	refquota, err := dataset.GetProperty("refquota")
+	assert.NoError(t, err)
 
 	if reserve {
 		assert.Equal(t, refquota, refreserved)
 	} else {
-		assert.Equal(t, nil, refreserved)
+		assert.Equal(t, "none", refreserved)
 	}
 }
 

--- a/test/provision_integration_test.go
+++ b/test/provision_integration_test.go
@@ -6,7 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/ccremer/kubernetes-zfs-provisioner/pkg/zfs"
-	gozfs "github.com/mistifyio/go-zfs"
+	gozfs "github.com/mistifyio/go-zfs/v3"
 	"math/rand"
 	"os"
 	"strconv"

--- a/test/provision_integration_test.go
+++ b/test/provision_integration_test.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"context"
 	"flag"
-	"github.com/ccremer/kubernetes-zfs-provisioner/pkg/zfs"
 	gozfs "github.com/mistifyio/go-zfs/v3"
 	"math/rand"
 	"os"
@@ -23,6 +22,7 @@ import (
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/v8/controller"
 
 	"github.com/ccremer/kubernetes-zfs-provisioner/pkg/provisioner"
+	"github.com/ccremer/kubernetes-zfs-provisioner/pkg/zfs"
 )
 
 var (


### PR DESCRIPTION
Fixes #101 

~~I'm going to test this next, but you can have a look at the code before I'm done.~~ Has been tested. 

Also I'm going to send a separate PR in which I will add the parameter to the example config in the helm chart. #103

## Summary
I've added an optional parameter to the storage classes, called "reserveSpace", which is true by default. When specified as "false", any datasets created when provisioning PVs using that storage class will not have a `RefReservation` set.

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [x] PR contains the label `area:provisioner`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.
