### PR TITLE
Add ReserveSpace parameter to StorageClass

### DIFF
--- a/charts/kubernetes-zfs-provisioner/Chart.yaml
+++ b/charts/kubernetes-zfs-provisioner/Chart.yaml
@@ -14,7 +14,7 @@ description: Dynamic ZFS persistent volume provisioner for Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.0
+version: 2.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/kubernetes-zfs-provisioner/README.md
+++ b/charts/kubernetes-zfs-provisioner/README.md
@@ -1,6 +1,6 @@
 # kubernetes-zfs-provisioner
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square)
 
 Dynamic ZFS persistent volume provisioner for Kubernetes
 

--- a/charts/kubernetes-zfs-provisioner/templates/storageclass.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/storageclass.yaml
@@ -19,6 +19,6 @@ parameters:
   type: {{ .type | default "nfs" }}
   node: {{ .node | default "''" }}
   shareProperties: {{ .shareProperties | default "''" }}
-  reserveSpace: {{ .reserveSpace | default "true" }}
+  reserveSpace: {{ coalesce (quote .reserveSpace) (quote true) }}
 {{- end }}
 {{- end }}

--- a/charts/kubernetes-zfs-provisioner/templates/storageclass.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/storageclass.yaml
@@ -19,6 +19,6 @@ parameters:
   type: {{ .type | default "nfs" }}
   node: {{ .node | default "''" }}
   shareProperties: {{ .shareProperties | default "''" }}
-  reserveSpace: {{ .reserveSpace || "true" }}
+  reserveSpace: {{ .reserveSpace | default "true" }}
 {{- end }}
 {{- end }}

--- a/charts/kubernetes-zfs-provisioner/templates/storageclass.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/storageclass.yaml
@@ -19,5 +19,6 @@ parameters:
   type: {{ .type | default "nfs" }}
   node: {{ .node | default "''" }}
   shareProperties: {{ .shareProperties | default "''" }}
+  reserveSpace: {{ .reserveSpace || "true" }}
 {{- end }}
 {{- end }}

--- a/charts/kubernetes-zfs-provisioner/test/storageclass_test.go
+++ b/charts/kubernetes-zfs-provisioner/test/storageclass_test.go
@@ -59,6 +59,51 @@ func Test_StorageClass_GivenClassesEnabled_WhenNodeDefined_ThenRenderNodeName(t 
 	assert.Equal(t, "hostpath", class.Parameters["type"])
 }
 
+func Test_StorageClass_GivenClassesEnabled_WhenReserveSpaceUndefined_ThenRenderDefault(t *testing.T) {
+	options := &helm.Options{
+		ValuesFiles: []string{"values/storageclass_1.yaml"},
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplStorageclass)
+
+	var class v1.StorageClass
+	helm.UnmarshalK8SYaml(t, output, &class)
+
+	assert.Equal(t, "true", class.Parameters["reserveSpace"])
+}
+
+func Test_StorageClass_GivenClassesEnabled_WhenReserveSpaceFalse_ThenRenderReserveSpace(t *testing.T) {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"storageClass.create":                  "true",
+			"storageClass.classes[0].reserveSpace": "false",
+		},
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplStorageclass)
+
+	var class v1.StorageClass
+	helm.UnmarshalK8SYaml(t, output, &class)
+
+	assert.Equal(t, "false", class.Parameters["reserveSpace"])
+}
+
+func Test_StorageClass_GivenClassesEnabled_WhenReserveSpaceTrue_ThenRenderReserveSpace(t *testing.T) {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"storageClass.create":                  "true",
+			"storageClass.classes[0].reserveSpace": "true",
+		},
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplStorageclass)
+
+	var class v1.StorageClass
+	helm.UnmarshalK8SYaml(t, output, &class)
+
+	assert.Equal(t, "true", class.Parameters["reserveSpace"])
+}
+
 func Test_StorageClass_GivenClassesEnabled_WhenAdditionalParametersUndefined_ThenRenderEmptyValues(t *testing.T) {
 	options := &helm.Options{
 		ValuesFiles: []string{"values/storageclass_1.yaml"},

--- a/charts/kubernetes-zfs-provisioner/values.yaml
+++ b/charts/kubernetes-zfs-provisioner/values.yaml
@@ -42,6 +42,8 @@ storageClass:
     #   # -- Override `kubernetes.io/hostname` from `hostName` parameter for
     #   # `HostPath` node affinity
     #   node: ""
+    #   # -- Reserve space for created datasets. Default is true. Use false to enable thin provisioning
+    #   reserveSpace: true
     #   # -- Annotations for the storage class
     #   # annotations:
     #   #   storageclass.kubernetes.io/is-default-class: "true"


### PR DESCRIPTION
## Summary

* Updated the helm chart and example in values.yaml for #102.

## Checklist

### For Helm Chart changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:kubernetes-zfs-provisioner`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.
