### PR TITLE
Only render reserveSpace parameter if explicitly set

### DIFF
--- a/charts/kubernetes-zfs-provisioner/Chart.yaml
+++ b/charts/kubernetes-zfs-provisioner/Chart.yaml
@@ -14,7 +14,7 @@ description: Dynamic ZFS persistent volume provisioner for Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.2.0
+version: 2.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/kubernetes-zfs-provisioner/README.md
+++ b/charts/kubernetes-zfs-provisioner/README.md
@@ -1,6 +1,6 @@
 # kubernetes-zfs-provisioner
 
-![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square)
+![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square)
 
 Dynamic ZFS persistent volume provisioner for Kubernetes
 
@@ -76,4 +76,3 @@ No 1.x or 0.x chart releases will be migrated from the `ccremer/charts` Helm rep
 * The `image.registry` has changed from `quay.io` to `ghcr.io`.
 * The `image.tag` has changed from to `v1.1.0` to `v1`.
 * The `image.pullPolicy` has changed from `IfNotPresent` to `Always`.
-

--- a/charts/kubernetes-zfs-provisioner/templates/storageclass.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/storageclass.yaml
@@ -19,6 +19,8 @@ parameters:
   type: {{ .type | default "nfs" }}
   node: {{ .node | default "''" }}
   shareProperties: {{ .shareProperties | default "''" }}
-  reserveSpace: {{ coalesce (quote .reserveSpace) (quote true) }}
+  {{- if kindIs "bool" .reserveSpace }}
+  reserveSpace: {{ quote .reserveSpace }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kubernetes-zfs-provisioner/test/storageclass_test.go
+++ b/charts/kubernetes-zfs-provisioner/test/storageclass_test.go
@@ -69,7 +69,9 @@ func Test_StorageClass_GivenClassesEnabled_WhenReserveSpaceUndefined_ThenRenderD
 	var class v1.StorageClass
 	helm.UnmarshalK8SYaml(t, output, &class)
 
-	assert.Equal(t, "true", class.Parameters["reserveSpace"])
+	value, exists := class.Parameters["reserveSpace"]
+	assert.False(t, exists)
+	assert.Empty(t, value)
 }
 
 func Test_StorageClass_GivenClassesEnabled_WhenReserveSpaceFalse_ThenRenderReserveSpace(t *testing.T) {

--- a/charts/kubernetes-zfs-provisioner/values.yaml
+++ b/charts/kubernetes-zfs-provisioner/values.yaml
@@ -43,7 +43,7 @@ storageClass:
     #   # `HostPath` node affinity
     #   node: ""
     #   # -- Reserve space for created datasets. Default is true. Use false to enable thin provisioning
-    #   reserveSpace: true
+    #   reserveSpace: false
     #   # -- Annotations for the storage class
     #   # annotations:
     #   #   storageclass.kubernetes.io/is-default-class: "true"


### PR DESCRIPTION

## Summary

This is a change for backwards compatibility reasons. Previously existing storage classes can't be modified with new parameters. Thus, we only render it if it has been explicitly set (e.g. when rendering a new storage class). The controller defaults the value to 'true' internally, so omitting the parameter is fine.

Follow-up of #103 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:kubernetes-zfs-provisioner`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.

<!--
Remove the section and checklist items that do not apply.
For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
