### PR TITLE
Fix loadEnvironmentVariables.

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,9 +81,7 @@ func loadDefaultValues() {
 func loadEnvironmentVariables() {
 	prefix := "ZFS_"
 	err := koanfInstance.Load(env.Provider(prefix, ".", func(s string) string {
-		s = strings.TrimPrefix(s, prefix)
-		s = strings.Replace(strings.ToLower(s), "_", "-", -1)
-		return s
+		return strings.ToLower(strings.TrimPrefix(s, prefix))
 	}), nil)
 	if err != nil {
 		klog.Fatalf("Could not load environment variables: %v", err)


### PR DESCRIPTION
Do not replace underscores (_) with hyphens (-) when converting environment variable names to config keys.

This fixes overriding the provisioner instance with the ZFS_PROVISIONER_INSTANCE environment variable.
