### PR TITLE
Add ability to run the provisioner directly on the ZFS host.

### DIFF
--- a/docker/update-permissions.sh
+++ b/docker/update-permissions.sh
@@ -5,7 +5,9 @@ set -eo pipefail
 zfs_mod="${ZFS_MOD:-g+w}"
 chmod_bin=${ZFS_CHOWN_BIN:-sudo -H chmod}
 
-zfs_host="${1}"
-zfs_mountpoint="${2}"
+zfs_mountpoint="${1}"
+
+# Do not try to manually modify these Env vars, they will be updated by the provisioner just before invoking the script.
+zfs_host="${ZFS_HOST}"
 
 ssh "${zfs_host}" "${chmod_bin} ${zfs_mod} ${zfs_mountpoint}"

--- a/test/update-permissions
+++ b/test/update-permissions
@@ -5,6 +5,6 @@ set -eo pipefail
 zfs_mod="${ZFS_MOD:-g+w}"
 chmod_bin=${ZFS_CHOWN_BIN:-chmod}
 
-zfs_mountpoint="${2}"
+zfs_mountpoint="${1}"
 
 ${chmod_bin} ${zfs_mod} ${zfs_mountpoint}


### PR DESCRIPTION
The default is to run kubernetes-zfs-provisioner in a container and create datasets via SSH on a remote host.
To do that, the docker image is created with the zfs and update-permissions stubs that will both call commands on the remote host using SSH.

Allows running kubernetes-zfs-provisioner directly on the ZFS host by making the update-permissions script presence optional. The zfs stub is already optional because it merely replaces the command of the same name on the remote host. The provisionner now uses the command specified in the ZFS_UPDATE_PERMISSIONS environment variable, which is set to /usr/bin/update-permissions by default in the docker image, otherwise it falls back to chmod.

Fixes #130.
