### PR TITLE
chart: make sure the deployment is deployed to the right namespace

### DIFF
--- a/charts/kubernetes-zfs-provisioner/templates/deployment.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "kubernetes-zfs-provisioner.fullname" . }}
   labels:
     {{- include "kubernetes-zfs-provisioner.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/kubernetes-zfs-provisioner/templates/secret.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "kubernetes-zfs-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes-zfs-provisioner.labels" . | nindent 4 }}
 stringData:

--- a/charts/kubernetes-zfs-provisioner/templates/serviceaccount.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kubernetes-zfs-provisioner.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes-zfs-provisioner.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
## Summary

* this simply sets the namespace of the deployment according to the namespace given to helm.

In my particular use-case I render the chart with kustomize, and put everything into the right namespace using the `--namespace` option to helm. Without the chart explicitly setting a namespace the deployment will end up in the currently active namespace - disjointed from the other resources it needs.

## Checklist

### For Helm Chart changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [ ] PR contains the label `area:chart`
- [ ] PR contains the chart label, e.g. `chart:kubernetes-zfs-provisioner`
- [X] Chart Version bumped if immediate release after merging is planned
- [X] I have run `make chart-docs`