### PR TITLE
Preserve argument boundaries in SSH wrappers

### DIFF
--- a/docker/update-permissions.sh
+++ b/docker/update-permissions.sh
@@ -10,4 +10,7 @@ zfs_mountpoint="${1}"
 # Do not try to manually modify these Env vars, they will be updated by the provisioner just before invoking the script.
 zfs_host="${ZFS_HOST}"
 
-ssh "${zfs_host}" "${chmod_bin} ${zfs_mod} ${zfs_mountpoint}"
+# Quote the mountpoint so a path containing spaces or shell metacharacters is
+# not re-split by the remote shell. chmod_bin/zfs_mod stay unquoted so
+# "sudo -H chmod" and mode flags keep splitting into separate words.
+ssh "${zfs_host}" "${chmod_bin} ${zfs_mod} $(printf '%q' "${zfs_mountpoint}")"

--- a/docker/zfs.sh
+++ b/docker/zfs.sh
@@ -7,4 +7,15 @@ zfs_bin=${ZFS_BIN:-sudo -H zfs}
 # Do not try to manually modify these Env vars, they will be updated by the provisioner just before invoking the script.
 zfs_host="${ZFS_HOST}"
 
-ssh "${zfs_host}" "${zfs_bin} ${*}"
+# Quote each argument individually so values that legitimately contain spaces
+# or shell metacharacters survive parsing by the remote shell. Without this,
+# "${*}" is flattened into one string and the remote shell re-splits it on
+# whitespace: a multi-network "sharenfs=rw=@a ro=@b" would reach zfs(8) as two
+# arguments and the create would fail. zfs_bin is intentionally left unquoted so
+# "sudo -H zfs" keeps splitting into separate words.
+remote_cmd="${zfs_bin}"
+for arg in "$@"; do
+	remote_cmd="${remote_cmd} $(printf '%q' "${arg}")"
+done
+
+ssh "${zfs_host}" "${remote_cmd}"


### PR DESCRIPTION
`docker/zfs.sh` and `docker/update-permissions.sh` build the remote command by
flattening every argument into a single string — `ssh "$host" "${zfs_bin} ${*}"` —
which the remote login shell then re-splits on whitespace. Any argument that
legitimately contains a space is broken apart before it reaches `zfs(8)`.

The reachable case is a multi-network NFS export. ZFS expresses multiple exports
as a **space-separated** `sharenfs` value, so a StorageClass like:

```yaml
parameters:
  shareProperties: "rw=@10.0.0.0/8 ro=@192.168.0.0/16"
```

is passed by go-zfs as a single `-o sharenfs=rw=@10.0.0.0/8 ro=@192.168.0.0/16`
argument, but the wrapper flattens it and the host shell re-splits it, so
`zfs create` receives `ro=@192.168.0.0/16` as a stray positional argument and fails.

Reproduced by emulating the remote shell (a fake `ssh` that runs the command
string through `bash -c` with a fake `zfs` that prints its argv):

```
before:  argv = [create] [-o] [sharenfs=rw=@10.0.0.0/8] [ro=@192.168.0.0/16] [tank/…]   (5 args — broken)
after:   argv = [create] [-o] [sharenfs=rw=@10.0.0.0/8 ro=@192.168.0.0/16] [tank/…]      (4 args — intact)
```

Fix: quote each argument with `printf '%q'` so spaces and shell metacharacters
survive remote parsing. `zfs_bin`/`chmod_bin` stay unquoted so `sudo -H zfs`
still word-splits as intended. `shellcheck` already flags the current form as
SC2029. No behaviour change for the common single-export case.
