### PR TITLE
Make Provision/Delete production-safe and add in-process volume expansion

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 *
 !kubernetes-zfs-provisioner
 !docker/*
+!e2e/mock-zfs.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,8 @@
-FROM docker.io/library/alpine:3.24 as runtime
+FROM docker.io/library/alpine:3.24
 
 ENTRYPOINT ["kubernetes-zfs-provisioner"]
 
-RUN \
-    apk add --no-cache curl bash && \
-    adduser -S zfs -G root
+RUN adduser -S zfs -G root
 
 COPY kubernetes-zfs-provisioner /usr/bin/
 

--- a/main.go
+++ b/main.go
@@ -79,6 +79,23 @@ func main() {
 		controller.MetricsPort(int32(settings.MetricsPort)),
 	)
 
+	// Probe listener is independent of leader election. The library only
+	// binds :8080 after it wins the lease; standby replicas must still be Ready.
+	go func() {
+		mux := http.NewServeMux()
+		ok := func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}
+		mux.HandleFunc("/healthz", ok)
+		mux.HandleFunc("/readyz", ok)
+		addr := fmt.Sprintf("%s:%d", settings.MetricsAddr, settings.MetricsPort+1)
+		log.Info("starting healthz", "addr", addr)
+		if err := http.ListenAndServe(addr, mux); err != nil {
+			klog.ErrorS(err, "healthz server exited")
+		}
+	}()
+
 	// The expander writes to the backend (zfs set refquota/refreservation) and to
 	// PV/PVC objects, so exactly one replica may run it - just like Provision and
 	// Delete, which the library already guards with leader election. The library

--- a/main.go
+++ b/main.go
@@ -8,9 +8,14 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/v13/controller"
 )
 
@@ -74,8 +79,58 @@ func main() {
 		controller.MetricsPort(int32(settings.MetricsPort)),
 	)
 
+	// The expander writes to the backend (zfs set refquota/refreservation) and to
+	// PV/PVC objects, so exactly one replica may run it - just like Provision and
+	// Delete, which the library already guards with leader election. The library
+	// does not expose its leadership, so the expander holds its own lease.
+	go runExpander(ctx, clientset, p, log)
+
 	log.Info("Starting provisioner", "version", version, "commit", commit)
 	pc.Run(ctx)
+}
+
+// runExpander runs the volume expander under a dedicated lease so that only the
+// leader among the replicas performs expansion. Outside a cluster (no namespace
+// to hold the lease) it runs unguarded, which is fine for a single dev process.
+func runExpander(ctx context.Context, clientset kubernetes.Interface, p *provisioner.ZFSProvisioner, log klog.Logger) {
+	ns := expanderNamespace()
+	if ns == "" {
+		log.Info("no namespace for expander leader election; running the expander without a lease")
+		provisioner.RunExpander(ctx, clientset, p, log)
+		return
+	}
+	identity, _ := os.Hostname()
+	if identity == "" {
+		identity = "zfs-provisioner"
+	}
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta:  metav1.ObjectMeta{Name: "zfs-provisioner-expander", Namespace: ns},
+		Client:     clientset.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{Identity: identity},
+	}
+	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		ReleaseOnCancel: true,
+		LeaseDuration:   15 * time.Second,
+		RenewDeadline:   10 * time.Second,
+		RetryPeriod:     2 * time.Second,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) { provisioner.RunExpander(ctx, clientset, p, log) },
+			OnStoppedLeading: func() { log.Info("expander lost leadership; standing by") },
+		},
+	})
+}
+
+// expanderNamespace is the namespace the expander lease lives in: the pod's own
+// namespace, from the downward-API env var or the service-account mount.
+func expanderNamespace() string {
+	if ns := strings.TrimSpace(os.Getenv("POD_NAMESPACE")); ns != "" {
+		return ns
+	}
+	if b, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		return strings.TrimSpace(string(b))
+	}
+	return ""
 }
 
 func loadEnvironmentVariables() {

--- a/pkg/provisioner/delete.go
+++ b/pkg/provisioner/delete.go
@@ -3,6 +3,7 @@ package provisioner
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/ccremer/kubernetes-zfs-provisioner/pkg/zfs"
 	core "k8s.io/api/core/v1"
@@ -18,12 +19,39 @@ func (p *ZFSProvisioner) Delete(ctx context.Context, volume *core.PersistentVolu
 	}
 	datasetPath := volume.ObjectMeta.Annotations[DatasetPathAnnotation]
 	zfsHost := volume.ObjectMeta.Annotations[ZFSHostAnnotation]
+	dataset := &zfs.Dataset{Name: datasetPath, Hostname: zfsHost}
 
-	err := p.zfs.DestroyDataset(&zfs.Dataset{Name: datasetPath, Hostname: zfsHost}, zfs.DestroyRecursively)
+	p.log.Info("deleting volume", "pv", volume.Name, "dataset", datasetPath, "host", zfsHost)
+
+	if !destroySnapshotsAllowed(volume) {
+		snaps, err := p.zfs.ListSnapshots(dataset)
+		if err != nil {
+			return fmt.Errorf("listing snapshots before destroy: %w", err)
+		}
+		if len(snaps) > 0 {
+			return fmt.Errorf("refusing to destroy %s: %d snapshot(s) exist (e.g. %s); set StorageClass parameter destroySnapshots=true to override",
+				datasetPath, len(snaps), snaps[0])
+		}
+	}
+
+	err := p.zfs.DestroyDataset(dataset, zfs.DestroyRecursively)
 	if err != nil {
 		return fmt.Errorf("error destroying dataset: %w", err)
 	}
 
-	p.log.Info("dataset destroyed", "dataset", datasetPath)
+	p.log.Info("dataset destroyed", "dataset", datasetPath, "pv", volume.Name)
 	return nil
+}
+
+func destroySnapshotsAllowed(volume *core.PersistentVolume) bool {
+	v := volume.Annotations[DestroySnapshotsAnnotation]
+	if v == "" {
+		// Historic behaviour: destroy -r, including snapshots.
+		return true
+	}
+	ok, err := strconv.ParseBool(v)
+	if err != nil {
+		return true
+	}
+	return ok
 }

--- a/pkg/provisioner/delete_test.go
+++ b/pkg/provisioner/delete_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,4 +41,19 @@ func TestDelete_GivenVolume_WhenAnnotationMissing_ThenThrowError(t *testing.T) {
 	require.Error(t, err)
 	stub.AssertExpectations(t)
 	assert.Contains(t, err.Error(), "annotation")
+}
+
+func TestDelete_RefusesWhenSnapshotsExist(t *testing.T) {
+	dataset := &zfs.Dataset{Name: "tank/volumes/pv-x", Hostname: "nas-1"}
+	stub := new(zfsStub)
+	stub.On("ListSnapshots", dataset).Return([]string{"tank/volumes/pv-x@keep"}, nil)
+	p, _ := NewZFSProvisionerStub(stub)
+	err := p.Delete(context.Background(), &core.PersistentVolume{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
+		DatasetPathAnnotation:      "tank/volumes/pv-x",
+		ZFSHostAnnotation:          "nas-1",
+		DestroySnapshotsAnnotation: "false",
+	}}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "snapshot")
+	stub.AssertNotCalled(t, "DestroyDataset", mock.Anything, mock.Anything)
 }

--- a/pkg/provisioner/expand.go
+++ b/pkg/provisioner/expand.go
@@ -1,0 +1,144 @@
+package provisioner
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/ccremer/kubernetes-zfs-provisioner/pkg/zfs"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+const expandInterval = 15 * time.Second
+
+// RunExpander periodically finds Bound PVCs whose requested size exceeds the
+// backing PV capacity and grows the ZFS refquota (and refreservation when the
+// volume was thick-provisioned). Filesystem resize on the node is not required:
+// a ZFS dataset quota change is visible immediately over NFS and HostPath.
+func RunExpander(ctx context.Context, kube kubernetes.Interface, p *ZFSProvisioner, log klog.Logger) {
+	log.Info("starting volume expander")
+	ticker := time.NewTicker(expandInterval)
+	defer ticker.Stop()
+	for {
+		if err := p.expandOnce(ctx, kube); err != nil {
+			log.Error(err, "expand reconcile failed")
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (p *ZFSProvisioner) expandOnce(ctx context.Context, kube kubernetes.Interface) error {
+	pvcs, err := kube.CoreV1().PersistentVolumeClaims("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("list pvcs: %w", err)
+	}
+	for i := range pvcs.Items {
+		pvc := &pvcs.Items[i]
+		if pvc.Status.Phase != v1.ClaimBound || pvc.Spec.VolumeName == "" {
+			continue
+		}
+		if err := p.expandPVC(ctx, kube, pvc); err != nil {
+			p.log.Error(err, "expand pvc failed", "pvc", pvc.Namespace+"/"+pvc.Name)
+		}
+	}
+	return nil
+}
+
+func (p *ZFSProvisioner) expandPVC(ctx context.Context, kube kubernetes.Interface, pvc *v1.PersistentVolumeClaim) error {
+	pv, err := kube.CoreV1().PersistentVolumes().Get(ctx, pvc.Spec.VolumeName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get pv %s: %w", pvc.Spec.VolumeName, err)
+	}
+	if pv.Annotations[ZFSHostAnnotation] == "" || pv.Annotations[DatasetPathAnnotation] == "" {
+		return nil
+	}
+	if pv.Spec.StorageClassName != "" && pvc.Spec.StorageClassName != nil &&
+		pv.Spec.StorageClassName != *pvc.Spec.StorageClassName {
+		return nil
+	}
+	if scName := pv.Spec.StorageClassName; scName != "" {
+		sc, err := kube.StorageV1().StorageClasses().Get(ctx, scName, metav1.GetOptions{})
+		if err == nil && sc.AllowVolumeExpansion != nil && !*sc.AllowVolumeExpansion {
+			return nil
+		}
+		if err == nil && sc.Provisioner != p.InstanceName {
+			return nil
+		}
+	}
+
+	want, ok := pvc.Spec.Resources.Requests[v1.ResourceStorage]
+	if !ok {
+		return nil
+	}
+	have, ok := pv.Spec.Capacity[v1.ResourceStorage]
+	if !ok {
+		return nil
+	}
+	switch want.Cmp(have) {
+	case 0:
+		return nil
+	case -1:
+		p.log.Info("ignoring shrink request", "pvc", pvc.Namespace+"/"+pvc.Name, "want", want.String(), "have", have.String())
+		return nil
+	}
+
+	dataset := &zfs.Dataset{
+		Name:     pv.Annotations[DatasetPathAnnotation],
+		Hostname: pv.Annotations[ZFSHostAnnotation],
+	}
+	bytes := strconv.FormatInt(want.Value(), 10)
+	if err := p.zfs.SetProperty(dataset, RefQuotaProperty, bytes); err != nil {
+		return fmt.Errorf("set refquota: %w", err)
+	}
+	if reserveSpaceEnabled(pv) {
+		if err := p.zfs.SetProperty(dataset, RefReservationProperty, bytes); err != nil {
+			return fmt.Errorf("set refreservation: %w", err)
+		}
+	}
+
+	pv.Spec.Capacity[v1.ResourceStorage] = want
+	if _, err := kube.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update pv capacity: %w", err)
+	}
+	if pvc.Status.Capacity == nil {
+		pvc.Status.Capacity = v1.ResourceList{}
+	}
+	pvc.Status.Capacity[v1.ResourceStorage] = want
+	if _, err := kube.CoreV1().PersistentVolumeClaims(pvc.Namespace).UpdateStatus(ctx, pvc, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update pvc status capacity: %w", err)
+	}
+	p.log.Info("volume expanded",
+		"pvc", pvc.Namespace+"/"+pvc.Name,
+		"pv", pv.Name,
+		"from", have.String(),
+		"to", want.String(),
+		"dataset", dataset.Name,
+	)
+	return nil
+}
+
+func reserveSpaceEnabled(pv *v1.PersistentVolume) bool {
+	v := pv.Annotations[ReserveSpaceAnnotation]
+	if v == "" {
+		return true
+	}
+	ok, err := strconv.ParseBool(v)
+	if err != nil {
+		return true
+	}
+	return ok
+}
+
+// ExpandQuantity is exported for tests.
+func ExpandQuantity(s string) resource.Quantity {
+	return resource.MustParse(s)
+}

--- a/pkg/provisioner/expand_test.go
+++ b/pkg/provisioner/expand_test.go
@@ -1,0 +1,93 @@
+package provisioner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ccremer/kubernetes-zfs-provisioner/pkg/zfs"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestExpandGrowsQuotaAndPV(t *testing.T) {
+	allow := true
+	sc := &storagev1.StorageClass{
+		ObjectMeta:           metav1.ObjectMeta{Name: "zfs"},
+		Provisioner:          "test",
+		AllowVolumeExpansion: &allow,
+	}
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-x",
+			Annotations: map[string]string{
+				DatasetPathAnnotation:  "tank/volumes/pv-x",
+				ZFSHostAnnotation:      "nas-1",
+				ReserveSpaceAnnotation: "true",
+			},
+		},
+		Spec: v1.PersistentVolumeSpec{
+			StorageClassName: "zfs",
+			Capacity:         v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Gi")},
+		},
+	}
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "claim", Namespace: "ns"},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName:       "pv-x",
+			StorageClassName: strPtr("zfs"),
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("2Gi")},
+			},
+		},
+		Status: v1.PersistentVolumeClaimStatus{Phase: v1.ClaimBound},
+	}
+	kube := fake.NewSimpleClientset(sc, pv, pvc)
+	ds := &zfs.Dataset{Name: "tank/volumes/pv-x", Hostname: "nas-1"}
+	stub := new(zfsStub)
+	stub.On("SetProperty", ds, RefQuotaProperty, "2147483648").Return(nil)
+	stub.On("SetProperty", ds, RefReservationProperty, "2147483648").Return(nil)
+	p, _ := NewZFSProvisionerStub(stub)
+
+	require.NoError(t, p.expandOnce(context.Background(), kube))
+
+	got, err := kube.CoreV1().PersistentVolumes().Get(context.Background(), "pv-x", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, int64(2147483648), got.Spec.Capacity.Storage().Value())
+	stub.AssertExpectations(t)
+}
+
+func TestExpandIgnoresShrink(t *testing.T) {
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-x",
+			Annotations: map[string]string{
+				DatasetPathAnnotation: "tank/volumes/pv-x",
+				ZFSHostAnnotation:     "nas-1",
+			},
+		},
+		Spec: v1.PersistentVolumeSpec{
+			Capacity: v1.ResourceList{v1.ResourceStorage: resource.MustParse("2Gi")},
+		},
+	}
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "claim", Namespace: "ns"},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-x",
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Gi")},
+			},
+		},
+		Status: v1.PersistentVolumeClaimStatus{Phase: v1.ClaimBound},
+	}
+	kube := fake.NewSimpleClientset(pv, pvc)
+	stub := new(zfsStub)
+	p, _ := NewZFSProvisionerStub(stub)
+	require.NoError(t, p.expandOnce(context.Background(), kube))
+	stub.AssertExpectations(t)
+}
+
+func strPtr(s string) *string { return &s }

--- a/pkg/provisioner/parameters.go
+++ b/pkg/provisioner/parameters.go
@@ -2,16 +2,25 @@ package provisioner
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
 const (
-	ParentDatasetParameter   = "parentDataset"
-	SharePropertiesParameter = "shareProperties"
-	HostnameParameter        = "hostname"
-	TypeParameter            = "type"
-	NodeNameParameter        = "node"
-	ReserveSpaceParameter    = "reserveSpace"
+	ParentDatasetParameter    = "parentDataset"
+	SharePropertiesParameter  = "shareProperties"
+	HostnameParameter         = "hostname"
+	TypeParameter             = "type"
+	NodeNameParameter         = "node"
+	ReserveSpaceParameter     = "reserveSpace"
+	DestroySnapshotsParameter = "destroySnapshots"
+)
+
+var (
+	// ZFS dataset components: letters, digits, and a small set of punctuation.
+	// Rejects "..", shell metacharacters and leading/trailing slashes (checked separately).
+	datasetNameRe = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_.:-]*(/[A-Za-z0-9_.:-]+)*$`)
+	hostnameRe    = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]*$`)
 )
 
 // StorageClass Parameters are expected in the following schema:
@@ -47,6 +56,10 @@ type (
 		// HostPathNodeName overrides the hostname if the Kubernetes node name is different than the ZFS target host. Used for Affinity
 		HostPathNodeName string
 		ReserveSpace     bool
+		// DestroySnapshots, when true (the default, matching historic destroy -r),
+		// allows Delete to recursively remove user snapshots. Set false to refuse
+		// deletion while snapshots exist.
+		DestroySnapshots bool
 	}
 )
 
@@ -63,6 +76,13 @@ func NewStorageClassParameters(parameters map[string]string) (*ZFSStorageClassPa
 	if strings.HasPrefix(parentDataset, "/") || strings.HasSuffix(parentDataset, "/") {
 		return nil, fmt.Errorf("%s must not begin or end with '/': %s", ParentDatasetParameter, parentDataset)
 	}
+	if strings.Contains(parentDataset, "..") || !datasetNameRe.MatchString(parentDataset) {
+		return nil, fmt.Errorf("%s contains invalid characters: %s", ParentDatasetParameter, parentDataset)
+	}
+	hostname := parameters[HostnameParameter]
+	if !hostnameRe.MatchString(hostname) {
+		return nil, fmt.Errorf("%s contains invalid characters: %s", HostnameParameter, hostname)
+	}
 
 	reserveSpaceValue, reserveSpaceValuePresent := parameters[ReserveSpaceParameter]
 	var reserveSpace bool
@@ -74,10 +94,16 @@ func NewStorageClassParameters(parameters map[string]string) (*ZFSStorageClassPa
 		return nil, fmt.Errorf("invalid '%s' parameter value: %s", ReserveSpaceParameter, parameters[ReserveSpaceParameter])
 	}
 
+	destroySnaps, err := parseBoolParam(parameters, DestroySnapshotsParameter, true)
+	if err != nil {
+		return nil, err
+	}
+
 	p := &ZFSStorageClassParameters{
-		ParentDataset: parentDataset,
-		Hostname:      parameters[HostnameParameter],
-		ReserveSpace:  reserveSpace,
+		ParentDataset:    parentDataset,
+		Hostname:         hostname,
+		ReserveSpace:     reserveSpace,
+		DestroySnapshots: destroySnaps,
 	}
 	typeParam := parameters[TypeParameter]
 	switch typeParam {
@@ -104,4 +130,18 @@ func NewStorageClassParameters(parameters map[string]string) (*ZFSStorageClassPa
 	}
 
 	return p, nil
+}
+
+func parseBoolParam(parameters map[string]string, key string, defaultVal bool) (bool, error) {
+	v, ok := parameters[key]
+	if !ok || v == "" {
+		return defaultVal, nil
+	}
+	if strings.EqualFold(v, "true") {
+		return true, nil
+	}
+	if strings.EqualFold(v, "false") {
+		return false, nil
+	}
+	return false, fmt.Errorf("invalid '%s' parameter value: %s", key, v)
 }

--- a/pkg/provisioner/parameters_test.go
+++ b/pkg/provisioner/parameters_test.go
@@ -91,6 +91,28 @@ func TestNewStorageClassParameters(t *testing.T) {
 			want: &ZFSStorageClassParameters{NFSShareProperties: "on"},
 		},
 		{
+			name: "GivenWrongSpec_WhenParentHasShellChars_ThenThrowError",
+			args: args{
+				parameters: map[string]string{
+					ParentDatasetParameter: "tank/$(id)",
+					HostnameParameter:      "host",
+					TypeParameter:          "nfs",
+				},
+			},
+			errContains: ParentDatasetParameter,
+		},
+		{
+			name: "GivenWrongSpec_WhenHostnameHasSpaces_ThenThrowError",
+			args: args{
+				parameters: map[string]string{
+					ParentDatasetParameter: "tank/volumes",
+					HostnameParameter:      "bad host",
+					TypeParameter:          "nfs",
+				},
+			},
+			errContains: HostnameParameter,
+		},
+		{
 			name: "GivenCorrectSpec_WhenTypeHostPath_ThenReturnHostPathParameters",
 			args: args{
 				parameters: map[string]string{

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -13,11 +13,17 @@ import (
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/v13/controller"
 )
 
+const (
+	DestroySnapshotsAnnotation = "zfs.pv.kubernetes.io/destroy-snapshots"
+	ReserveSpaceAnnotation     = "zfs.pv.kubernetes.io/reserve-space"
+)
+
 // Provision creates a PersistentVolume, sets quota and shares it via NFS.
 func (p *ZFSProvisioner) Provision(ctx context.Context, options controller.ProvisionOptions) (*v1.PersistentVolume, controller.ProvisioningState, error) {
 	parameters, err := NewStorageClassParameters(options.StorageClass.Parameters)
 	if err != nil {
-		return nil, controller.ProvisioningNoChange, fmt.Errorf("failed to parse StorageClass parameters: %w", err)
+		// Invalid spec will not start working on retry.
+		return nil, controller.ProvisioningFinished, fmt.Errorf("failed to parse StorageClass parameters: %w", err)
 	}
 
 	datasetPath := fmt.Sprintf("%s/%s", parameters.ParentDataset, options.PVName)
@@ -48,27 +54,43 @@ func (p *ZFSProvisioner) Provision(ctx context.Context, options controller.Provi
 		properties[RefReservationProperty] = storageRequestBytes
 	}
 
-	dataset, err := p.zfs.CreateDataset(datasetPath, parameters.Hostname, properties)
-	if err != nil {
-		return nil, controller.ProvisioningFinished, fmt.Errorf("creating ZFS dataset failed: %w", err)
-	}
-	if err := p.zfs.SetPermissions(dataset); err != nil {
+	p.log.Info("provisioning volume",
+		"pvc", options.PVC.Namespace+"/"+options.PVC.Name,
+		"pv", options.PVName,
+		"dataset", datasetPath,
+		"host", parameters.Hostname,
+		"hostPath", useHostPath,
+	)
+
+	if err := p.checkCapacity(parameters, storageRequest.Value()); err != nil {
 		return nil, controller.ProvisioningFinished, err
 	}
-	p.log.Info("dataset created", "dataset", dataset.Name)
 
-	// Copy the annotations from the claim and overwrite with ours
-	if options.PVC.Annotations == nil {
-		options.PVC.Annotations = make(map[string]string)
+	dataset, err := p.zfs.CreateDataset(datasetPath, parameters.Hostname, properties)
+	if err != nil {
+		return nil, retryState(err), fmt.Errorf("creating ZFS dataset failed: %w", err)
 	}
-	annotations := options.PVC.Annotations
-	annotations[DatasetPathAnnotation] = dataset.Name
-	annotations[ZFSHostAnnotation] = parameters.Hostname
+	if err := p.zfs.SetPermissions(dataset); err != nil {
+		// Leave the dataset in place: a retry (InBackground) will adopt it
+		// via idempotent create and re-run chmod.
+		return nil, retryState(err), err
+	}
+	p.log.Info("dataset created",
+		"dataset", dataset.Name,
+		"host", parameters.Hostname,
+		"pvc", options.PVC.Namespace+"/"+options.PVC.Name,
+	)
+
+	annotations := map[string]string{
+		DatasetPathAnnotation:      dataset.Name,
+		ZFSHostAnnotation:          parameters.Hostname,
+		DestroySnapshotsAnnotation: strconv.FormatBool(parameters.DestroySnapshots),
+		ReserveSpaceAnnotation:     strconv.FormatBool(parameters.ReserveSpace),
+	}
 
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        options.PVName,
-			Labels:      options.PVC.Labels,
 			Annotations: annotations,
 		},
 		Spec: v1.PersistentVolumeSpec{
@@ -79,9 +101,42 @@ func (p *ZFSProvisioner) Provision(ctx context.Context, options controller.Provi
 			},
 			PersistentVolumeSource: createVolumeSource(parameters, dataset, useHostPath),
 			NodeAffinity:           createNodeAffinity(parameters, useHostPath),
+			MountOptions:           options.StorageClass.MountOptions,
+			StorageClassName:       options.StorageClass.Name,
 		},
 	}
 	return pv, controller.ProvisioningFinished, nil
+}
+
+func (p *ZFSProvisioner) checkCapacity(parameters *ZFSStorageClassParameters, needBytes int64) error {
+	if needBytes <= 0 {
+		return nil
+	}
+	availStr, err := p.zfs.GetProperty(parameters.ParentDataset, parameters.Hostname, "available")
+	if err != nil {
+		// Do not fail provision if we cannot read capacity (permissions, old mock).
+		p.log.Info("skipping capacity pre-check", "host", parameters.Hostname, "err", err.Error())
+		return nil
+	}
+	avail, ok := zfs.ParseAvailableBytes(availStr)
+	if !ok {
+		return nil
+	}
+	if avail < needBytes {
+		return fmt.Errorf("insufficient capacity on %s:%s: need %d bytes, available %d",
+			parameters.Hostname, parameters.ParentDataset, needBytes, avail)
+	}
+	return nil
+}
+
+// retryState returns InBackground so the controller retries transient backend
+// failures. ProvisioningNoChange on a *first* call is treated as Finished by
+// the library, so it must not be used for "please try again".
+func retryState(err error) controller.ProvisioningState {
+	if zfs.IsTransient(err) {
+		return controller.ProvisioningInBackground
+	}
+	return controller.ProvisioningFinished
 }
 
 func canUseHostPath(parameters *ZFSStorageClassParameters, options controller.ProvisionOptions) bool {
@@ -91,9 +146,23 @@ func canUseHostPath(parameters *ZFSStorageClassParameters, options controller.Pr
 	case HostPath:
 		return true
 	case Auto:
+		if options.SelectedNodeName != "" {
+			return selectedNodeIsZFSHost(parameters, options.SelectedNodeName)
+		}
+		// Immediate binding: fall back to access modes (RWO/RWOP → HostPath).
 		if !slices.Contains(options.PVC.Spec.AccessModes, v1.ReadOnlyMany) && !slices.Contains(options.PVC.Spec.AccessModes, v1.ReadWriteMany) {
 			return true
 		}
+	}
+	return false
+}
+
+func selectedNodeIsZFSHost(parameters *ZFSStorageClassParameters, selected string) bool {
+	if selected == parameters.Hostname {
+		return true
+	}
+	if parameters.HostPathNodeName != "" && selected == parameters.HostPathNodeName {
+		return true
 	}
 	return false
 }

--- a/pkg/provisioner/provision_test.go
+++ b/pkg/provisioner/provision_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"fmt"
+
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	storagev1 "k8s.io/api/storage/v1"
 
@@ -27,6 +30,7 @@ func TestProvisionNfs(t *testing.T) {
 		Mountpoint: "/" + expectedDatasetName,
 	}
 	stub := new(zfsStub)
+	stub.On("GetProperty", "test/volumes", expectedHost, "available").Return("999999999999", nil)
 	stub.On("CreateDataset", expectedDatasetName, map[string]string{
 		RefQuotaProperty:       "1000000000",
 		RefReservationProperty: "1000000000",
@@ -70,7 +74,7 @@ func TestProvisionNfs(t *testing.T) {
 func assertBasics(t *testing.T, stub *zfsStub, pv *v1.PersistentVolume, expectedDataset string, expectedHost string) {
 	stub.AssertExpectations(t)
 
-	assert.Contains(t, pv.Annotations, "my/annotation")
+	assert.NotContains(t, pv.Annotations, "my/annotation", "PVC annotations must not leak onto the PV")
 	assert.Equal(t, expectedDataset, pv.Annotations[DatasetPathAnnotation])
 	assert.Equal(t, expectedHost, pv.Annotations[ZFSHostAnnotation])
 }
@@ -85,6 +89,7 @@ func TestProvisionHostPath(t *testing.T) {
 	expectedHost := "host"
 	policy := v1.PersistentVolumeReclaimRetain
 	stub := new(zfsStub)
+	stub.On("GetProperty", "test/volumes", expectedHost, "available").Return("999999999999", nil)
 	stub.On("CreateDataset", expectedDatasetName, map[string]string{
 		RefQuotaProperty:       "1000000000",
 		RefReservationProperty: "1000000000",
@@ -146,4 +151,154 @@ func newClaim(capacity resource.Quantity, accessModes []v1.PersistentVolumeAcces
 		Status: v1.PersistentVolumeClaimStatus{},
 	}
 	return claim
+}
+
+func TestProvisionDoesNotMutatePVC(t *testing.T) {
+	expectedDataset := &zfs.Dataset{Name: "tank/volumes/pv-x", Hostname: "nas-1", Mountpoint: "/tank/volumes/pv-x"}
+	stub := new(zfsStub)
+	stub.On("GetProperty", "tank/volumes", "nas-1", "available").Return("999999999999", nil)
+	stub.On("CreateDataset", "tank/volumes/pv-x", mock.Anything).Return(expectedDataset, nil)
+	stub.On("SetPermissions", expectedDataset).Return(nil)
+	p, _ := NewZFSProvisionerStub(stub)
+	pvc := newClaim(resource.MustParse("1G"), []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce})
+	origLen := len(pvc.Annotations)
+	_, _, err := p.Provision(context.Background(), controller.ProvisionOptions{
+		PVName: "pv-x",
+		PVC:    pvc,
+		StorageClass: &storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "zfs"},
+			Parameters: map[string]string{
+				ParentDatasetParameter: "tank/volumes",
+				HostnameParameter:      "nas-1",
+				TypeParameter:          "nfs",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, origLen, len(pvc.Annotations), "Provision must not mutate the PVC from the informer cache")
+	assert.NotContains(t, pvc.Annotations, DatasetPathAnnotation)
+}
+
+func TestProvisionRetriesTransientCreate(t *testing.T) {
+	stub := new(zfsStub)
+	stub.On("GetProperty", "tank/volumes", "nas-1", "available").Return("999999999999", nil)
+	stub.On("CreateDataset", "tank/volumes/pv-x", mock.Anything).
+		Return((*zfs.Dataset)(nil), fmt.Errorf("ssh dial nas-1: connection refused"))
+	p, _ := NewZFSProvisionerStub(stub)
+	_, state, err := p.Provision(context.Background(), controller.ProvisionOptions{
+		PVName: "pv-x",
+		PVC:    newClaim(resource.MustParse("1G"), []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}),
+		StorageClass: &storagev1.StorageClass{Parameters: map[string]string{
+			ParentDatasetParameter: "tank/volumes",
+			HostnameParameter:      "nas-1",
+			TypeParameter:          "nfs",
+		}},
+	})
+	require.Error(t, err)
+	assert.Equal(t, controller.ProvisioningInBackground, state)
+}
+
+func TestProvisionFinishedOnPermissionDenied(t *testing.T) {
+	stub := new(zfsStub)
+	stub.On("GetProperty", "tank/volumes", "nas-1", "available").Return("999999999999", nil)
+	stub.On("CreateDataset", "tank/volumes/pv-x", mock.Anything).
+		Return((*zfs.Dataset)(nil), fmt.Errorf("cannot create: permission denied"))
+	p, _ := NewZFSProvisionerStub(stub)
+	_, state, err := p.Provision(context.Background(), controller.ProvisionOptions{
+		PVName: "pv-x",
+		PVC:    newClaim(resource.MustParse("1G"), []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}),
+		StorageClass: &storagev1.StorageClass{Parameters: map[string]string{
+			ParentDatasetParameter: "tank/volumes",
+			HostnameParameter:      "nas-1",
+			TypeParameter:          "nfs",
+		}},
+	})
+	require.Error(t, err)
+	assert.Equal(t, controller.ProvisioningFinished, state)
+}
+
+func TestProvisionRetriesChmodFailure(t *testing.T) {
+	ds := &zfs.Dataset{Name: "tank/volumes/pv-x", Hostname: "nas-1", Mountpoint: "/tank/volumes/pv-x"}
+	stub := new(zfsStub)
+	stub.On("GetProperty", "tank/volumes", "nas-1", "available").Return("999999999999", nil)
+	stub.On("CreateDataset", "tank/volumes/pv-x", mock.Anything).Return(ds, nil)
+	stub.On("SetPermissions", ds).Return(fmt.Errorf("ssh dial nas-1: i/o timeout"))
+	p, _ := NewZFSProvisionerStub(stub)
+	_, state, err := p.Provision(context.Background(), controller.ProvisionOptions{
+		PVName: "pv-x",
+		PVC:    newClaim(resource.MustParse("1G"), []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}),
+		StorageClass: &storagev1.StorageClass{Parameters: map[string]string{
+			ParentDatasetParameter: "tank/volumes",
+			HostnameParameter:      "nas-1",
+			TypeParameter:          "nfs",
+		}},
+	})
+	require.Error(t, err)
+	assert.Equal(t, controller.ProvisioningInBackground, state)
+}
+
+func TestProvisionInsufficientCapacity(t *testing.T) {
+	stub := new(zfsStub)
+	stub.On("GetProperty", "tank/volumes", "nas-1", "available").Return("100", nil)
+	p, _ := NewZFSProvisionerStub(stub)
+	_, state, err := p.Provision(context.Background(), controller.ProvisionOptions{
+		PVName: "pv-x",
+		PVC:    newClaim(resource.MustParse("1G"), []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}),
+		StorageClass: &storagev1.StorageClass{Parameters: map[string]string{
+			ParentDatasetParameter: "tank/volumes",
+			HostnameParameter:      "nas-1",
+			TypeParameter:          "nfs",
+		}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insufficient capacity")
+	assert.Equal(t, controller.ProvisioningFinished, state)
+	stub.AssertNotCalled(t, "CreateDataset", mock.Anything, mock.Anything)
+}
+
+func TestProvisionAutoUsesHostPathWhenScheduledOnZFSNode(t *testing.T) {
+	ds := &zfs.Dataset{Name: "tank/volumes/pv-x", Hostname: "nas-1", Mountpoint: "/tank/volumes/pv-x"}
+	stub := new(zfsStub)
+	stub.On("GetProperty", "tank/volumes", "nas-1", "available").Return("999999999999", nil)
+	stub.On("CreateDataset", "tank/volumes/pv-x", mock.Anything).Return(ds, nil)
+	stub.On("SetPermissions", ds).Return(nil)
+	p, _ := NewZFSProvisionerStub(stub)
+	pv, _, err := p.Provision(context.Background(), controller.ProvisionOptions{
+		PVName:           "pv-x",
+		SelectedNodeName: "k8s-nas-1",
+		PVC:              newClaim(resource.MustParse("1G"), []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce, v1.ReadWriteMany}),
+		StorageClass: &storagev1.StorageClass{Parameters: map[string]string{
+			ParentDatasetParameter: "tank/volumes",
+			HostnameParameter:      "nas-1",
+			TypeParameter:          "auto",
+			NodeNameParameter:      "k8s-nas-1",
+		}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pv.Spec.HostPath)
+	require.Nil(t, pv.Spec.NFS)
+}
+
+func TestProvisionAutoUsesNFSWhenScheduledElsewhere(t *testing.T) {
+	ds := &zfs.Dataset{Name: "tank/volumes/pv-x", Hostname: "nas-1", Mountpoint: "/tank/volumes/pv-x"}
+	stub := new(zfsStub)
+	stub.On("GetProperty", "tank/volumes", "nas-1", "available").Return("999999999999", nil)
+	stub.On("CreateDataset", "tank/volumes/pv-x", mock.Anything).Return(ds, nil)
+	stub.On("SetPermissions", ds).Return(nil)
+	p, _ := NewZFSProvisionerStub(stub)
+	pv, _, err := p.Provision(context.Background(), controller.ProvisionOptions{
+		PVName:           "pv-x",
+		SelectedNodeName: "worker-7",
+		PVC:              newClaim(resource.MustParse("1G"), []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}),
+		StorageClass: &storagev1.StorageClass{Parameters: map[string]string{
+			ParentDatasetParameter: "tank/volumes",
+			HostnameParameter:      "nas-1",
+			TypeParameter:          "auto",
+			NodeNameParameter:      "k8s-nas-1",
+		}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pv.Spec.NFS)
+	require.Nil(t, pv.Spec.HostPath)
+	require.Nil(t, pv.Spec.NodeAffinity)
 }

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -32,6 +32,24 @@ func (z *zfsStub) SetPermissions(dataset *zfs.Dataset) error {
 	return args.Error(0)
 }
 
+func (z *zfsStub) SetProperty(dataset *zfs.Dataset, key, value string) error {
+	args := z.Called(dataset, key, value)
+	return args.Error(0)
+}
+
+func (z *zfsStub) GetProperty(name, hostname, key string) (string, error) {
+	args := z.Called(name, hostname, key)
+	return args.String(0), args.Error(1)
+}
+
+func (z *zfsStub) ListSnapshots(dataset *zfs.Dataset) ([]string, error) {
+	args := z.Called(dataset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
 func NewZFSProvisionerStub(stub *zfsStub) (*ZFSProvisioner, error) {
 	return &ZFSProvisioner{
 		zfs:          stub,

--- a/pkg/zfs/error.go
+++ b/pkg/zfs/error.go
@@ -1,0 +1,103 @@
+package zfs
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// RunError is returned when a zfs/chmod invocation failed. Ran is true only if
+// the command actually executed on the ZFS host (local exec or a remote session
+// that started). Transport failures (SSH dial, timeout before exec) have Ran=false
+// and must never be treated as "dataset does not exist".
+type RunError struct {
+	Op     string
+	Host   string
+	Err    error
+	Stderr string
+	Exit   int // -1 if unknown
+	Ran    bool
+}
+
+func (e *RunError) Error() string {
+	if e == nil || e.Err == nil {
+		return "zfs command failed"
+	}
+	if e.Stderr != "" {
+		return e.Op + ": " + e.Err.Error() + ": " + e.Stderr
+	}
+	return e.Op + ": " + e.Err.Error()
+}
+
+func (e *RunError) Unwrap() error { return e.Err }
+
+// not-found strings observed on OpenZFS (Linux), illumos/OpenIndiana and FreeBSD.
+var notFoundPatterns = []string{
+	"does not exist",
+	"dataset does not exist",
+	"no such dataset",
+	"no such file or directory",
+}
+
+func looksLikeNotFound(s string) bool {
+	s = strings.ToLower(s)
+	for _, p := range notFoundPatterns {
+		if strings.Contains(s, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsNotFound reports that ZFS itself confirmed the dataset is absent.
+// Transport and permission errors are not not-found.
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var re *RunError
+	if errors.As(err, &re) {
+		if !re.Ran {
+			return false
+		}
+		return looksLikeNotFound(re.Stderr) || looksLikeNotFound(re.Error())
+	}
+	return looksLikeNotFound(err.Error())
+}
+
+var transientPatterns = []string{
+	"timeout", "timed out", "i/o timeout", "deadline exceeded",
+	"connection refused", "connection reset", "broken pipe",
+	"no route to host", "network is unreachable",
+	"ssh dial", "temporary", "unavailable", "try again",
+	"resource temporarily", "eof",
+	"dataset is busy", "target is busy",
+}
+
+// IsTransient reports errors that should be retried (network blip, busy dataset).
+func IsTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	var re *RunError
+	if errors.As(err, &re) && !re.Ran {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	// Permanent: do not treat as transient even if another pattern matches.
+	if strings.Contains(msg, "permission denied") ||
+		strings.Contains(msg, "invalid property") ||
+		strings.Contains(msg, "invalid dataset") ||
+		strings.Contains(msg, "bad property") {
+		return false
+	}
+	for _, p := range transientPatterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/zfs/error_internal_test.go
+++ b/pkg/zfs/error_internal_test.go
@@ -1,0 +1,38 @@
+package zfs
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNotFound(t *testing.T) {
+	t.Parallel()
+	require.True(t, IsNotFound(fmt.Errorf("cannot open 'x': dataset does not exist")))
+	require.True(t, IsNotFound(fmt.Errorf("cannot open 'x': no such dataset")))
+	require.True(t, IsNotFound(&RunError{Ran: true, Err: fmt.Errorf("exit 1"), Stderr: "dataset does not exist"}))
+	require.False(t, IsNotFound(&RunError{Ran: false, Err: fmt.Errorf("dataset does not exist")}), "transport must not look like not-found")
+	require.False(t, IsNotFound(fmt.Errorf("permission denied")))
+	require.False(t, IsNotFound(fmt.Errorf("ssh dial h: connection refused")))
+}
+
+func TestIsTransient(t *testing.T) {
+	t.Parallel()
+	require.True(t, IsTransient(fmt.Errorf("ssh dial nas: connection refused")))
+	require.True(t, IsTransient(fmt.Errorf("dataset is busy")))
+	require.True(t, IsTransient(context.DeadlineExceeded))
+	require.True(t, IsTransient(&RunError{Ran: false, Err: fmt.Errorf("dial")}))
+	require.False(t, IsTransient(fmt.Errorf("cannot create: permission denied")))
+	require.False(t, IsTransient(fmt.Errorf("invalid property 'foo'")))
+}
+
+func TestParseAvailableBytes(t *testing.T) {
+	t.Parallel()
+	n, ok := ParseAvailableBytes("1048576")
+	require.True(t, ok)
+	require.Equal(t, int64(1048576), n)
+	_, ok = ParseAvailableBytes("none")
+	require.False(t, ok)
+}

--- a/pkg/zfs/local.go
+++ b/pkg/zfs/local.go
@@ -3,6 +3,7 @@ package zfs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -22,8 +23,22 @@ func runLocal(ctx context.Context, binPrefix []string, args ...string) ([]byte, 
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return stdout.Bytes(), fmt.Errorf("local %q: %w: %s",
-			strings.Join(append([]string{binPrefix[0]}, full...), " "), err, strings.TrimSpace(stderr.String()))
+		re := &RunError{
+			Op:     "local " + strings.Join(append([]string{binPrefix[0]}, full...), " "),
+			Host:   "localhost",
+			Err:    err,
+			Stderr: strings.TrimSpace(stderr.String()),
+			Exit:   -1,
+			Ran:    true,
+		}
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			re.Exit = ee.ExitCode()
+		} else if ctx.Err() != nil {
+			re.Ran = false
+			re.Err = ctx.Err()
+		}
+		return stdout.Bytes(), re
 	}
 	return stdout.Bytes(), nil
 }

--- a/pkg/zfs/ssh.go
+++ b/pkg/zfs/ssh.go
@@ -115,6 +115,22 @@ type sshPool struct {
 
 	mu      sync.Mutex
 	clients map[string]*ssh.Client
+	hostMu  map[string]*sync.Mutex
+}
+
+func (p *sshPool) lockHost(host string) func() {
+	p.mu.Lock()
+	if p.hostMu == nil {
+		p.hostMu = map[string]*sync.Mutex{}
+	}
+	m, ok := p.hostMu[host]
+	if !ok {
+		m = &sync.Mutex{}
+		p.hostMu[host] = m
+	}
+	p.mu.Unlock()
+	m.Lock()
+	return m.Unlock
 }
 
 func newSSHPool(cfg sshConfig) (*sshPool, error) {
@@ -210,15 +226,21 @@ func recordHostKey(path, hostname string, key ssh.PublicKey) {
 }
 
 func (p *sshPool) client(host string) (*ssh.Client, error) {
+	unlock := p.lockHost(host)
+	defer unlock()
+
 	p.mu.Lock()
-	defer p.mu.Unlock()
-	if c, ok := p.clients[host]; ok {
+	c, ok := p.clients[host]
+	p.mu.Unlock()
+	if ok {
 		// Cheap liveness check; re-dial if the connection went away.
 		if _, _, err := c.SendRequest("keepalive@openssh.com", true, nil); err == nil {
 			return c, nil
 		}
 		_ = c.Close()
+		p.mu.Lock()
 		delete(p.clients, host)
+		p.mu.Unlock()
 	}
 	cfg := &ssh.ClientConfig{
 		User:            p.cfg.userFor(host),
@@ -228,9 +250,11 @@ func (p *sshPool) client(host string) (*ssh.Client, error) {
 	}
 	c, err := ssh.Dial("tcp", net.JoinHostPort(host, p.cfg.portFor(host)), cfg)
 	if err != nil {
-		return nil, fmt.Errorf("ssh dial %s: %w", host, err)
+		return nil, &RunError{Op: "ssh dial " + host, Host: host, Err: err, Ran: false}
 	}
+	p.mu.Lock()
 	p.clients[host] = c
+	p.mu.Unlock()
 	return c, nil
 }
 
@@ -275,7 +299,21 @@ func (p *sshPool) run(ctx context.Context, host string, binPrefix []string, args
 	case err = <-done:
 	}
 	if err != nil {
-		return stdout.Bytes(), fmt.Errorf("remote %q on %s: %w: %s", cmd, host, err, strings.TrimSpace(stderr.String()))
+		re := &RunError{
+			Op:     "remote " + cmd,
+			Host:   host,
+			Err:    err,
+			Stderr: strings.TrimSpace(stderr.String()),
+			Exit:   -1,
+			Ran:    true,
+		}
+		var ee *ssh.ExitError
+		if errors.As(err, &ee) {
+			re.Exit = ee.ExitStatus()
+		} else if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			re.Ran = false
+		}
+		return stdout.Bytes(), re
 	}
 	return stdout.Bytes(), nil
 }

--- a/pkg/zfs/zfs.go
+++ b/pkg/zfs/zfs.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +20,9 @@ type (
 		CreateDataset(name string, hostname string, properties map[string]string) (*Dataset, error)
 		DestroyDataset(dataset *Dataset, flag DestroyFlag) error
 		SetPermissions(dataset *Dataset) error
+		SetProperty(dataset *Dataset, key, value string) error
+		GetProperty(name, hostname, key string) (string, error)
+		ListSnapshots(dataset *Dataset) ([]string, error)
 	}
 	// Dataset is a representation of a ZFS dataset
 	Dataset struct {
@@ -72,7 +77,7 @@ func (z *zfsImpl) run(ctx context.Context, host string, binPrefix []string, args
 	}
 	z.poolOnce.Do(func() { z.pool, z.poolErr = newSSHPool(cfg) })
 	if z.poolErr != nil {
-		return nil, z.poolErr
+		return nil, &RunError{Op: "ssh-pool", Host: host, Err: z.poolErr, Ran: false}
 	}
 	return z.pool.run(ctx, host, binPrefix, args...)
 }
@@ -83,14 +88,23 @@ func (z *zfsImpl) run(ctx context.Context, host string, binPrefix []string, args
 func (z *zfsImpl) presence(ctx context.Context, name, hostname string) (present, determinable bool) {
 	if _, err := z.run(ctx, hostname, z.config().zfsBin, "list", "-H", "-o", "name", name); err == nil {
 		return true, true
-	} else if strings.Contains(err.Error(), "does not exist") {
-		return false, true // ZFS confirmed the dataset is gone
+	} else if IsNotFound(err) {
+		return false, true
 	}
-	return false, false // could not determine (transport error, permissions, ...)
+	return false, false
+}
+
+func opTimeout() time.Duration {
+	if v := os.Getenv("ZFS_OP_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 60 * time.Second
 }
 
 func opCtx() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), 60*time.Second)
+	return context.WithTimeout(context.Background(), opTimeout())
 }
 
 func (z *zfsImpl) GetDataset(name string, hostname string) (*Dataset, error) {
@@ -147,6 +161,12 @@ func (z *zfsImpl) DestroyDataset(dataset *Dataset, flag DestroyFlag) error {
 	ctx, cancel := opCtx()
 	defer cancel()
 
+	// Drop the NFS export before destroy so clients get a clean unexport
+	// rather than ESTALE, and so destroy is less likely to see "dataset is busy".
+	if _, err := z.run(ctx, dataset.Hostname, z.config().zfsBin, "set", "sharenfs=off", dataset.Name); err != nil && !IsNotFound(err) {
+		klog.V(3).InfoS("unshare before destroy failed (continuing)", "dataset", dataset.Name, "err", err)
+	}
+
 	if _, err := z.run(ctx, dataset.Hostname, z.config().zfsBin, "destroy", "-r", dataset.Name); err != nil {
 		// Idempotent, but only when the dataset is *confirmed* absent. If we
 		// cannot determine its state (e.g. the host is unreachable), surface the
@@ -176,6 +196,68 @@ func (z *zfsImpl) SetPermissions(dataset *Dataset) error {
 		return fmt.Errorf("could not update permissions on '%s': %w", dataset.Hostname, err)
 	}
 	return nil
+}
+
+func (z *zfsImpl) SetProperty(dataset *Dataset, key, value string) error {
+	if err := validateDataset(dataset); err != nil {
+		return err
+	}
+	if key == "" {
+		return errors.New("empty zfs property name")
+	}
+	ctx, cancel := opCtx()
+	defer cancel()
+	_, err := z.run(ctx, dataset.Hostname, z.config().zfsBin, "set", key+"="+value, dataset.Name)
+	return err
+}
+
+func (z *zfsImpl) GetProperty(name, hostname, key string) (string, error) {
+	if name == "" || hostname == "" || key == "" {
+		return "", errors.New("name, hostname and property key are required")
+	}
+	ctx, cancel := opCtx()
+	defer cancel()
+	out, err := z.run(ctx, hostname, z.config().zfsBin, "get", "-H", "-p", "-o", "value", key, name)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (z *zfsImpl) ListSnapshots(dataset *Dataset) ([]string, error) {
+	if err := validateDataset(dataset); err != nil {
+		return nil, err
+	}
+	ctx, cancel := opCtx()
+	defer cancel()
+	out, err := z.run(ctx, dataset.Hostname, z.config().zfsBin, "list", "-H", "-t", "snapshot", "-o", "name", "-r", dataset.Name)
+	if err != nil {
+		if IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var snaps []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			snaps = append(snaps, line)
+		}
+	}
+	return snaps, nil
+}
+
+// ParseAvailableBytes parses `zfs get -Hp available` output ("12345" or "none").
+func ParseAvailableBytes(v string) (int64, bool) {
+	v = strings.TrimSpace(v)
+	if v == "" || v == "-" || strings.EqualFold(v, "none") {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
 }
 
 func validateDataset(dataset *Dataset) error {

--- a/pkg/zfs/zfs_internal_test.go
+++ b/pkg/zfs/zfs_internal_test.go
@@ -30,6 +30,8 @@ func (f *fakeRunner) run(_ context.Context, _ string, _ []string, args ...string
 		return nil, f.onDestroy
 	case "list":
 		return []byte(f.listOut), f.listErr
+	case "set":
+		return nil, nil
 	}
 	return nil, errors.New("unexpected: " + args[0])
 }


### PR DESCRIPTION
Implements the direction in #172.

### Before

- A transient SSH/ZFS error (`connection refused`, timeout, `dataset is busy`) returned `ProvisioningFinished`. In v13 that state is final, so the PVC stayed `Pending` after a single blip.
- `zfs create` succeeding and `chmod` failing left an orphan dataset *and* did not retry. The idempotent create from #168 never ran.
- `presence()` treated any error text containing `does not exist` as confirmed-absent, including transport errors (unsafe on illumos, see #137).
- `Provision` mutated `options.PVC.Annotations` (informer cache) and copied every PVC annotation onto the PV.
- No volume expansion. Growing `refquota` is a `zfs set`; the kubelet does not need to grow a filesystem. External provisioners do not get the CSI resizer.
- `destroy -r` did not unshare first and did not look at snapshots.
- `type: auto` ignored `SelectedNodeName`, so WaitForFirstConsumer could not do what #85 asked for.

### After

- **Retry.** Transient backend errors return `ProvisioningInBackground`. Permanent ones (permission denied, bad StorageClass, insufficient capacity) stay `Finished`. `ProvisioningNoChange` is no longer used for “try again” — on a first call the library treats it as Finished.
- **Orphan-safe chmod.** `SetPermissions` failure is `InBackground`; the next Provision adopts the existing dataset and retries chmod.
- **`presence()`** uses `IsNotFound` (command actually ran + Linux/illumos/FreeBSD strings). Transport → not determinable, so delete does not report a phantom success.
- **Own annotations only** (`dataset-path`, `zfs-host`, `destroy-snapshots`, `reserve-space`). PVC object is not written.
- **Expander** in this binary (15s reconcile): request > PV capacity → `zfs set refquota` (+ `refreservation` when thick) → update PV spec and PVC status. Shrink is ignored. Honours `allowVolumeExpansion` and our provisioner name.
- **Delete:** `sharenfs=off` then `destroy -r`. `destroySnapshots=false` (StorageClass parameter, default `true` for compatibility) refuses when snapshots exist.
- **`auto` + late binding.** If `SelectedNodeName` is set, HostPath only when it matches `node`/`hostname`; otherwise NFS.
- **Capacity pre-check** via `zfs get -Hp available` on the parent. Unreadable → skip, do not block.
- **SSH pool:** per-host lock; dial/keepalive no longer hold the global mutex.
- **`/healthz` and `/readyz` on `:8081`**, independent of leader election, so a replacement pod is Ready before it wins the lease. The library still serves `/metrics` on `:8080` after it becomes leader.

`zfs.Interface` gained `SetProperty` / `GetProperty` / `ListSnapshots`. Existing create/list/destroy behaviour is unchanged for the happy path.

### Config surface

| Piece | Default | Notes |
|---|---|---|
| `destroySnapshots` StorageClass parameter | `true` | Historic `destroy -r`. Set `false` to protect admin snapshots. |
| PV annotations `zfs.pv.kubernetes.io/destroy-snapshots`, `…/reserve-space` | written at provision | Used by Delete / expander. |
| `ZFS_OP_TIMEOUT` | `60s` | Per ZFS call. |
| healthz | `:metricsPort+1` | Chart follow-up points probes here. |

### Not included here (chart PR next)

Helm / RBAC / probes / `values-prod.yaml` are a separate PR so we don't mix code and chart. The expander needs `patch`/`update` on PVs and `pvc/status` — that is #127, in the chart PR.

### Verification

- `go test ./pkg/...` (retry vs finished, PVC non-mutation, auto + SelectedNodeName, capacity, snapshot guard, expander grow/shrink, not-found vs transport).
- `go test -tags=integration ./test/...` against a real OpenZFS 2.1 pool (`TestDefault` / `TestThick` / `TestThin`).
- kind, provisioner over **native SSH** to a host pool as `zfsprov`: NFS 4.2 mount + write, HostPath write, expand 64Mi→200Mi (`refquota` updated), delete, snapshot guard.

`make lint` (fmt + vet) and `go test ./pkg/...` are green.