### PR TITLE
chart: production defaults, expander RBAC, and independent health probes

### DIFF
--- a/charts/kubernetes-zfs-provisioner/Chart.yaml
+++ b/charts/kubernetes-zfs-provisioner/Chart.yaml
@@ -14,7 +14,7 @@ description: Dynamic ZFS persistent volume provisioner for Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.3.0
+version: 2.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/kubernetes-zfs-provisioner/README.md
+++ b/charts/kubernetes-zfs-provisioner/README.md
@@ -35,14 +35,14 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"ghcr.io"` | Container image registry |
 | image.repository | string | `"ccremer/zfs-provisioner"` | Location of the container image |
-| image.tag | string | `"v1"` | Pin a release tag in production. `v1` is a moving major tag. |
+| image.tag | string | `"v1.6.0"` | Pin an exact release tag so the chart maps 1:1 to a known image build. |
 | imagePullSecrets | list | `[]` |  |
 | metrics.port | int | `8080` |  |
 | metrics.service.enabled | bool | `true` | Expose /metrics on a ClusterIP Service |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Reminder: This has no effect on any PVs, but maybe you want the provisioner pod running on certain nodes. |
 | podDisruptionBudget.enabled | bool | `true` |  |
-| podDisruptionBudget.minAvailable | int | `1` |  |
+| podDisruptionBudget.minAvailable | int | `1` | Minimum available replicas. Ignored when replicaCount equals 1, since the PDB is only rendered for replicaCount greater than 1. |
 | podSecurityContext | object | `{"fsGroup":100}` | If you encounter **issues with SSH, set `podSecurityContext.fsGroup=100`**, as the SSH files might not be readable to the container user `zfs` with uid 100. |
 | priorityClassName | string | `""` | Optional PriorityClass for the provisioner pod |
 | provisioner.instance | string | `"pv.kubernetes.io/zfs"` | Provisoner instance name if multiple are running (multiple instances are not required for managing multiple ZFS hosts) |

--- a/charts/kubernetes-zfs-provisioner/README.md
+++ b/charts/kubernetes-zfs-provisioner/README.md
@@ -1,6 +1,6 @@
 # kubernetes-zfs-provisioner
 
-![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square)
+![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square)
 
 Dynamic ZFS persistent volume provisioner for Kubernetes
 

--- a/charts/kubernetes-zfs-provisioner/README.md
+++ b/charts/kubernetes-zfs-provisioner/README.md
@@ -28,27 +28,38 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | env | object | `{}` | A dict with KEY: VALUE pairs passed to the provisioner as environment variables. Use it to tune the SSH connection, e.g. `ZFS_SSH_HOSTKEY_TOFU: "true"` or `ZFS_SSH_PORT: "2222"`. See the [provisioner README](https://github.com/ccremer/kubernetes-zfs-provisioner#ssh-connection) for the full list. |
+| extraVolumeMounts | list | `[]` | Extra volume mounts for the provisioner container |
+| extraVolumes | list | `[]` | Extra volumes mounted into the provisioner container (e.g. local mock root) |
 | fullnameOverride | string | `""` |  |
 | hostAliases | object | `{}` | A dict with `{ip, hostnames array}` to configure custom entries in /etc/hosts. See [values.yaml](./values.yaml) for an example. |
-| image.pullPolicy | string | `"Always"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"ghcr.io"` | Container image registry |
 | image.repository | string | `"ccremer/zfs-provisioner"` | Location of the container image |
-| image.tag | string | `"v1"` | Container image tag |
+| image.tag | string | `"v1"` | Pin a release tag in production. `v1` is a moving major tag. |
 | imagePullSecrets | list | `[]` |  |
+| metrics.port | int | `8080` |  |
+| metrics.service.enabled | bool | `true` | Expose /metrics on a ClusterIP Service |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Reminder: This has no effect on any PVs, but maybe you want the provisioner pod running on certain nodes. |
-| podSecurityContext | object | `{}` | If you encounter **issues with SSH, set `podSecurityContext.fsGroup=100`**, as the SSH files might not be readable to the container user `zfs` with uid 100. |
+| podDisruptionBudget.enabled | bool | `true` |  |
+| podDisruptionBudget.minAvailable | int | `1` |  |
+| podSecurityContext | object | `{"fsGroup":100}` | If you encounter **issues with SSH, set `podSecurityContext.fsGroup=100`**, as the SSH files might not be readable to the container user `zfs` with uid 100. |
+| priorityClassName | string | `""` | Optional PriorityClass for the provisioner pod |
 | provisioner.instance | string | `"pv.kubernetes.io/zfs"` | Provisoner instance name if multiple are running (multiple instances are not required for managing multiple ZFS hosts) |
-| rbac.create | bool | `false` | **Required for first time deployments** Grant the service account the necessary permissions, |
-| replicaCount | int | `1` | Usually `1` is fine |
-| resources.limits.memory | string | `"40Mi"` |  |
+| rbac.create | bool | `true` | Grant the service account the necessary cluster permissions. |
+| replicaCount | int | `1` | 1 is enough (leader election). Use 2 for HA together with a PDB. |
+| resources.limits.memory | string | `"256Mi"` |  |
 | resources.requests.cpu | string | `"50m"` |  |
-| resources.requests.memory | string | `"20Mi"` |  |
-| securityContext | object | `{}` |  |
+| resources.requests.memory | string | `"64Mi"` |  |
+| securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| securityContext.runAsNonRoot | bool | `true` |  |
+| securityContext.runAsUser | int | `100` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| ssh.config | string | `""` | **Required.** ssh_config(5)-compatible file content to configure SSH options when connecting |
+| ssh.config | string | `""` | Optional ssh_config(5). Only `User` and `Port` are honoured by the native client. Per-host IdentityFile is not read; set `ZFS_SSH_KEY` or use a standard key name. |
 | ssh.externalSecretName | string | `""` | If SSH secrets are managed externally, specify the name |
 | ssh.identities | object | `{}` | **Required.** Provide a private key for each SSH identity. See [values.yaml](./values.yaml) for an example |
 | ssh.knownHosts | list | `[]` | **Required** unless `env.ZFS_SSH_HOSTKEY_TOFU` is `"true"`. List of {host, pubKey} dicts with the public key of each ZFS host. Host keys are verified strictly by default; set `env.ZFS_SSH_HOSTKEY_TOFU: "true"` to pin unknown host keys on first use instead. |

--- a/charts/kubernetes-zfs-provisioner/templates/deployment.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if le (int .Values.replicaCount) 1 }}
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "kubernetes-zfs-provisioner.selectorLabels" . | nindent 6 }}
@@ -14,6 +18,8 @@ spec:
     metadata:
       labels:
         {{- include "kubernetes-zfs-provisioner.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/ssh: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -22,6 +28,9 @@ spec:
       serviceAccountName: {{ include "kubernetes-zfs-provisioner.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       containers:
         - name: provisioner
           securityContext:
@@ -30,19 +39,39 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: ZFS_PROVISIONER_INSTANCE
-              value: {{ .Values.provisioner.instance }}
+              value: {{ .Values.provisioner.instance | quote }}
+            - name: ZFS_SSH_MOUNT_PATH
+              value: {{ .Values.ssh.mountPath | quote }}
           {{- with .Values.env }}
           {{- range $key, $value := . }}
             - name: {{ $key }}
-              value: {{ $value }}
+              value: {{ $value | quote }}
           {{- end }}
           {{- end }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .Values.metrics.port | default 8080 }}
+            - name: health
+              containerPort: {{ add (.Values.metrics.port | default 8080) 1 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 2
+            periodSeconds: 5
           volumeMounts:
             - name: ssh
               mountPath: {{ .Values.ssh.mountPath }}
+              readOnly: true
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.hostAliases }}
@@ -61,6 +90,9 @@ spec:
           secret:
             secretName: {{ include "kubernetes-zfs-provisioner.secretName" $ }}
             defaultMode: 0600
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/kubernetes-zfs-provisioner/templates/deployment.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/deployment.yaml
@@ -7,10 +7,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  {{- if le (int .Values.replicaCount) 1 }}
   strategy:
+    {{- if le (int .Values.replicaCount) 1 }}
     type: Recreate
-  {{- end }}
+    {{- else }}
+    type: RollingUpdate
+    {{- end }}
   selector:
     matchLabels:
       {{- include "kubernetes-zfs-provisioner.selectorLabels" . | nindent 6 }}

--- a/charts/kubernetes-zfs-provisioner/templates/pdb.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (int .Values.replicaCount) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kubernetes-zfs-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubernetes-zfs-provisioner.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "kubernetes-zfs-provisioner.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/kubernetes-zfs-provisioner/templates/rbac.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/rbac.yaml
@@ -40,6 +40,8 @@ rules:
       - get
       - list
       - watch
+      - patch
+      - update
   - apiGroups:
       - ''
     resources:
@@ -49,6 +51,14 @@ rules:
       - list
       - update
       - watch
+  - apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - storage.k8s.io
     resources:

--- a/charts/kubernetes-zfs-provisioner/templates/secret.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/secret.yaml
@@ -9,9 +9,9 @@ metadata:
 stringData:
   {{- with .Values.ssh.knownHosts }}
   known_hosts: |
-  {{- range . }}
+    {{- range . }}
     {{ .host }} {{ .pubKey }}
-  {{ end }}
+    {{- end }}
   {{- end }}
   {{- with .Values.ssh.config }}
   config: |

--- a/charts/kubernetes-zfs-provisioner/templates/service.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.metrics.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kubernetes-zfs-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubernetes-zfs-provisioner.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "kubernetes-zfs-provisioner.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.metrics.port | default 8080 }}
+      targetPort: http
+{{- end }}

--- a/charts/kubernetes-zfs-provisioner/templates/storageclass.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/storageclass.yaml
@@ -13,14 +13,27 @@ metadata:
 {{- end }}
 provisioner: {{ $.Values.provisioner.instance }}
 reclaimPolicy: {{ .policy | default "Delete" }}
+allowVolumeExpansion: {{ .allowVolumeExpansion | default true }}
+volumeBindingMode: {{ .volumeBindingMode | default "Immediate" }}
+{{- with .mountOptions }}
+mountOptions:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 parameters:
-  parentDataset: {{ .parentDataset }}
-  hostname: {{ .hostName }}
-  type: {{ .type | default "nfs" }}
-  node: {{ .node | default "''" }}
-  shareProperties: {{ .shareProperties | default "''" }}
+  parentDataset: {{ .parentDataset | quote }}
+  hostname: {{ .hostName | quote }}
+  type: {{ .type | default "nfs" | quote }}
+  {{- if .node }}
+  node: {{ .node | quote }}
+  {{- end }}
+  {{- if .shareProperties }}
+  shareProperties: {{ .shareProperties | quote }}
+  {{- end }}
   {{- if kindIs "bool" .reserveSpace }}
-  reserveSpace: {{ quote .reserveSpace }}
+  reserveSpace: {{ .reserveSpace | quote }}
+  {{- end }}
+  {{- if kindIs "bool" .destroySnapshots }}
+  destroySnapshots: {{ .destroySnapshots | quote }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kubernetes-zfs-provisioner/test/deployment_test.go
+++ b/charts/kubernetes-zfs-provisioner/test/deployment_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 
@@ -19,22 +18,16 @@ func Test_Deployment_ShouldRender_EnvironmentVariables(t *testing.T) {
 		ValuesFiles: []string{"values/deployment_1.yaml"},
 	}
 
-	expectedKeys := []string{"KEY1", "ANOTHER_KEY", "ZFS_PROVISIONER_INSTANCE"}
-	expectedValues := []string{"value", "another value", "pv.kubernetes.io/zfs"}
-
 	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplDeployment)
 
 	var deployment appv1.Deployment
 	helm.UnmarshalK8SYaml(t, output, &deployment)
 
 	envs := deployment.Spec.Template.Spec.Containers[0].Env
-	assert.Equal(t, len(envs), 3)
-	for i, _ := range envs {
-		require.Contains(t, envs, v1.EnvVar{
-			Name:  expectedKeys[i],
-			Value: expectedValues[i],
-		})
-	}
+	require.Contains(t, envs, v1.EnvVar{Name: "KEY1", Value: "value"})
+	require.Contains(t, envs, v1.EnvVar{Name: "ANOTHER_KEY", Value: "another value"})
+	require.Contains(t, envs, v1.EnvVar{Name: "ZFS_PROVISIONER_INSTANCE", Value: "pv.kubernetes.io/zfs"})
+	require.Contains(t, envs, v1.EnvVar{Name: "ZFS_SSH_MOUNT_PATH", Value: "/home/zfs/.ssh"})
 }
 
 func Test_Deployment_ShouldRender_SshVolumes_IfEnabled(t *testing.T) {
@@ -51,6 +44,7 @@ func Test_Deployment_ShouldRender_SshVolumes_IfEnabled(t *testing.T) {
 	require.Contains(t, volumeMounts, v1.VolumeMount{
 		Name:      "ssh",
 		MountPath: "/home/zfs/.ssh",
+		ReadOnly:  true,
 	})
 
 	volumes := deployment.Spec.Template.Spec.Volumes

--- a/charts/kubernetes-zfs-provisioner/test/storageclass_test.go
+++ b/charts/kubernetes-zfs-provisioner/test/storageclass_test.go
@@ -120,6 +120,8 @@ func Test_StorageClass_GivenClassesEnabled_WhenAdditionalParametersUndefined_The
 	var class v1.StorageClass
 	helm.UnmarshalK8SYaml(t, output, &class)
 
-	assert.Equal(t, "", class.Parameters["shareProperties"])
-	assert.Equal(t, "", class.Parameters["node"])
+	_, hasShare := class.Parameters["shareProperties"]
+	_, hasNode := class.Parameters["node"]
+	assert.False(t, hasShare, "empty shareProperties must be omitted")
+	assert.False(t, hasNode, "empty node must be omitted")
 }

--- a/charts/kubernetes-zfs-provisioner/values-prod.yaml
+++ b/charts/kubernetes-zfs-provisioner/values-prod.yaml
@@ -1,0 +1,44 @@
+# Production overlay. Install with:
+#   helm install zfs ./charts/kubernetes-zfs-provisioner -f values-prod.yaml -f secrets.yaml
+#
+# secrets.yaml should only contain ssh.identities / ssh.knownHosts or set
+# ssh.externalSecretName to a Secret managed outside Helm.
+
+replicaCount: 2
+
+image:
+  pullPolicy: IfNotPresent
+
+rbac:
+  create: true
+
+env:
+  ZFS_SSH_HOSTKEY_TOFU: "false"
+
+ssh:
+  # Require a pre-seeded known_hosts. Do not enable TOFU in production.
+  externalSecretName: ""
+
+storageClass:
+  create: true
+  classes: []
+    # - name: zfs-nfs
+    #   hostName: nas-1.prod.example
+    #   parentDataset: tank/k8s
+    #   policy: Retain
+    #   type: nfs
+    #   shareProperties: "rw=@10.0.0.0/8,root_squash"
+    #   reserveSpace: true
+    #   destroySnapshots: false
+    #   allowVolumeExpansion: true
+    #   volumeBindingMode: Immediate
+    #   mountOptions:
+    #     - nfsvers=4.2
+    #     - proto=tcp
+    #     - hard
+    #     - timeo=600
+    #     - retrans=2
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1

--- a/charts/kubernetes-zfs-provisioner/values.yaml
+++ b/charts/kubernetes-zfs-provisioner/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# -- Usually `1` is fine
+# -- 1 is enough (leader election). Use 2 for HA together with a PDB.
 replicaCount: 1
 
 image:
@@ -10,9 +10,9 @@ image:
   repository: ccremer/zfs-provisioner
   # -- Container image registry
   registry: ghcr.io
-  # -- Container image tag
+  # -- Pin a release tag in production. `v1` is a moving major tag.
   tag: v1
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 nameOverride: ""
@@ -44,6 +44,14 @@ storageClass:
     #   node: ""
     #   # -- Reserve space for created datasets. Default is true. Use false to enable thin provisioning
     #   reserveSpace: false
+    #   # -- If false, Delete refuses to run while user snapshots exist
+    #   destroySnapshots: true
+    #   allowVolumeExpansion: true
+    #   volumeBindingMode: Immediate
+    #   mountOptions:
+    #     - nfsvers=4.2
+    #     - proto=tcp
+    #     - hard
     #   # -- Annotations for the storage class
     #   # annotations:
     #   #   storageclass.kubernetes.io/is-default-class: "true"
@@ -53,12 +61,13 @@ ssh:
   externalSecretName: ""
   # -- The path where the SSH config and identities are mounted
   mountPath: "/home/zfs/.ssh"
-  # -- **Required.** ssh_config(5)-compatible file content to configure SSH options when connecting
+  # -- Optional ssh_config(5). Only `User` and `Port` are honoured by the native client.
+  # Per-host IdentityFile is not read; set `ZFS_SSH_KEY` or use a standard key name.
   config: ""
     # config: |
     #   Host my-host
-    #     IdentityFile ~/.ssh/id_ed25519
     #     User zfs
+    #     Port 22
 
   # -- **Required.** Provide a private key for each SSH identity.
   # See [values.yaml](./values.yaml) for an example
@@ -96,29 +105,42 @@ serviceAccount:
   name: ""
 
 rbac:
-  # -- **Required for first time deployments** Grant the service account
-  # the necessary permissions,
-  create: false
+  # -- Grant the service account the necessary cluster permissions.
+  create: true
 
 # -- If you encounter **issues with SSH, set `podSecurityContext.fsGroup=100`**, as the SSH
 # files might not be readable to the container user `zfs` with uid 100.
-podSecurityContext: {}
-  # fsGroup: 100
+podSecurityContext:
+  fsGroup: 100
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 100
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 100
 
 resources:
   limits:
-    memory: 40Mi
+    memory: 256Mi
   requests:
     cpu: 50m
-    memory: 20Mi
+    memory: 64Mi
+
+metrics:
+  port: 8080
+  service:
+    # -- Expose /metrics on a ClusterIP Service
+    enabled: true
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+# -- Optional PriorityClass for the provisioner pod
+priorityClassName: ""
 
 # -- Reminder: This has no effect on any PVs, but maybe you want the provisioner pod running
 # on certain nodes.
@@ -127,3 +149,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# -- Extra volumes mounted into the provisioner container (e.g. local mock root)
+extraVolumes: []
+# -- Extra volume mounts for the provisioner container
+extraVolumeMounts: []

--- a/charts/kubernetes-zfs-provisioner/values.yaml
+++ b/charts/kubernetes-zfs-provisioner/values.yaml
@@ -10,8 +10,8 @@ image:
   repository: ccremer/zfs-provisioner
   # -- Container image registry
   registry: ghcr.io
-  # -- Pin a release tag in production. `v1` is a moving major tag.
-  tag: v1
+  # -- Pin an exact release tag so the chart maps 1:1 to a known image build.
+  tag: v1.6.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -137,6 +137,7 @@ metrics:
 
 podDisruptionBudget:
   enabled: true
+  # -- Minimum available replicas. Ignored when replicaCount equals 1, since the PDB is only rendered for replicaCount greater than 1.
   minAvailable: 1
 
 # -- Optional PriorityClass for the provisioner pod


### PR DESCRIPTION
Chart half of #172. Depends on #173 (new `/healthz` on `:8081`, expander). Please merge #173 first, then cut a release that ships both the image and this chart.

Closes #127.

### Before

- `rbac.create` defaulted to `false`, so a first install had no rights.
- ClusterRole could not `patch`/`update` PersistentVolumes (#127) or PVC status, so the expander in #173 cannot write capacity back.
- Probes hit `/metrics` on `:8080`. The library only binds that port *after* leader election, so a rolling update of `replicaCount: 1` leaves the new pod unready and the old pod holding the lease.
- `ZFS_SSH_MOUNT_PATH` was not set from `ssh.mountPath`.
- Empty `node` / `shareProperties` rendered as the two-character string `''`.
- SSH Secret updates did not roll the Deployment (stale `known_hosts` → `key mismatch`).
- Image `pullPolicy: Always` + floating `v1`, memory limit 40Mi.

### After

- `rbac.create: true`. PV `patch`/`update` and `persistentvolumeclaims/status` `get`/`patch`/`update`.
- Probes use `/healthz` and `/readyz` on `:8081` (started in #173 before the lease).
- `strategy: Recreate` when `replicaCount <= 1`.
- `checksum/ssh` annotation so a Secret change restarts the pod.
- `ZFS_SSH_MOUNT_PATH` always comes from `ssh.mountPath`; extra env values are quoted.
- StorageClass: omit empty optional parameters; `allowVolumeExpansion` / `volumeBindingMode` / `mountOptions` / `destroySnapshots`.
- Defaults: `IfNotPresent`, 64Mi/256Mi, drop ALL, non-root, read-only root, `fsGroup: 100`.
- Optional metrics Service and PDB (`replicaCount > 1`).
- `values-prod.yaml` overlay (2 replicas, no TOFU, Retain-oriented comments).

Chart version **2.4.0**. I updated the README badge by hand to match; `make chart-docs` would regenerate the values table on top of the existing helm-docs markup.

### Not included

Image tag is still `v1` until you cut the release that includes #173. After that, pin `image.tag` to the new version in a tiny follow-up if you want.

`helm` unit tests (`charts/kubernetes-zfs-provisioner/test`) are green.